### PR TITLE
Summarization Utility

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -36,6 +36,11 @@
         "negotiator": "0.6.2"
       }
     },
+    "afinn-165": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-1.0.4.tgz",
+      "integrity": "sha512-7+Wlx3BImrK0HiG6y3lU4xX7SpBPSSu8T9iguPMlaueRFxjbYwAQrp9lqZUuFikqKbd/en8lVREILvP2J80uJA=="
+    },
     "ansi-align": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
@@ -77,6 +82,14 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "apparatus": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
+      "integrity": "sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==",
+      "requires": {
+        "sylvester": ">= 0.0.8"
       }
     },
     "array-flatten": {
@@ -270,6 +283,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -693,6 +711,19 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
     "kareem": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
@@ -871,10 +902,31 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "natural": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/natural/-/natural-0.6.3.tgz",
+      "integrity": "sha512-78fcEdNN6Y4pv8SOLPDhJTlUG+8IiQzNx0nYpl0k7q00K4ZZuds+wDWfSa6eeiPcSQDncvV44WWGsi70/ZP3+w==",
+      "requires": {
+        "afinn-165": "^1.0.2",
+        "apparatus": "^0.0.10",
+        "json-stable-stringify": "^1.0.1",
+        "sylvester": "^0.0.12",
+        "underscore": "^1.3.1"
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "node-summarizer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/node-summarizer/-/node-summarizer-1.0.7.tgz",
+      "integrity": "sha512-kHgVyhm+k97/50ActxLFIemHLvYPwHLJfwF3tEg2TqeL5xmUCCytqRwdiO3LyBRFMUopLJjisSlkJwTk72gVbg==",
+      "requires": {
+        "natural": "^0.6.3",
+        "wordpos": "^1.2.0"
+      }
     },
     "nodemon": {
       "version": "2.0.4",
@@ -1298,6 +1350,11 @@
         "has-flag": "^3.0.0"
       }
     },
+    "sylvester": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.12.tgz",
+      "integrity": "sha1-WohEFc0tACxX56OqyZRip1zp/bQ="
+    },
     "term-size": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
@@ -1358,6 +1415,11 @@
       "requires": {
         "debug": "^2.2.0"
       }
+    },
+    "underscore": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
+      "integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw=="
     },
     "unique-string": {
       "version": "2.0.0",
@@ -1421,6 +1483,21 @@
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "requires": {
         "string-width": "^4.0.0"
+      }
+    },
+    "wordnet-db": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/wordnet-db/-/wordnet-db-3.1.14.tgz",
+      "integrity": "sha512-zVyFsvE+mq9MCmwXUWHIcpfbrHHClZWZiVOzKSxNJruIcFn2RbY55zkhiAMMxM8zCVSmtNiViq8FsAZSFpMYag=="
+    },
+    "wordpos": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/wordpos/-/wordpos-1.2.0.tgz",
+      "integrity": "sha512-3C0pdLnYIV962dyPEmi+QNJhI+RRz2lLY1QiCycUt2qhL8Dalv1huAngfePDmNJ1WHdSAT/fjbDqtbu1KfguCw==",
+      "requires": {
+        "commander": "^2.0.0",
+        "underscore": ">=1.3.1",
+        "wordnet-db": "^3.1.6"
       }
     },
     "wrappy": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "mongoose": "^5.10.3",
+    "node-summarizer": "^1.0.7",
     "nodemon": "^2.0.4"
   }
 }

--- a/backend/utils/summarization.js
+++ b/backend/utils/summarization.js
@@ -1,10 +1,9 @@
 const SummarizerManager = require("node-summarizer").SummarizerManager;
 
-function summarize (text) {
+async function summarize (text) {
   let Summarizer = new SummarizerManager(text.body, text.numSentences);
-  return Summarizer.getSummaryByRank().then(summary_obj => {
-    return summary_obj.summary;
-  });
+  const summary_obj = await Summarizer.getSummaryByRank();
+  return summary_obj.summary;
 }
 
 module.exports = summarize;

--- a/backend/utils/summarization.js
+++ b/backend/utils/summarization.js
@@ -2,7 +2,7 @@ const SummarizerManager = require("node-summarizer").SummarizerManager;
 
 function summarize (text) {
   let Summarizer = new SummarizerManager(text.body, text.numSentences);
-  Summarizer.getSummaryByRank().then(summary_obj => {
+  return Summarizer.getSummaryByRank().then(summary_obj => {
     return summary_obj.summary;
   });
 }

--- a/backend/utils/summarization.js
+++ b/backend/utils/summarization.js
@@ -1,0 +1,10 @@
+const SummarizerManager = require("node-summarizer").SummarizerManager;
+
+function summarize (text) {
+  let Summarizer = new SummarizerManager(text.body, text.numSentences);
+  Summarizer.getSummaryByRank().then(summary_obj => {
+    return summary_obj.summary;
+  });
+}
+
+module.exports = summarize;


### PR DESCRIPTION
### Problem
We don't have a method to summarize pieces of text, which was the idea that gave rise to this entire project.

### Solution
Add a function that takes in a body of text and returns a summary. This utilizes the `node-summarizer` package, which uses a weighted graph traversal approach to summarizing text. This function can be called in our API endpoints for Email Summarization and Document Summarization.

### Testing
This was tested by temporarily introducing a console log into an already exposed route. I passed a few different bodies of text into this function and got a good summary as output. 

### Notes
In the future, this function should now be able to be altered (we could even completely change the summarization approach), but the routes that call it should not be affected.

Closes #20 