### PR TITLE
Docker Bugfix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     command: npm start
     volumes:
       - ./client/:/usr/src/app
-      - /usr/app/node_modules
+      - /usr/src/app/node_modules
     depends_on:
       - server
     ports:


### PR DESCRIPTION
### Problem
When setting up on a fresh machine or a machine where the `node_modules` aren't installed locally, the React Client wasn't properly installing the `node_modules` in the Docker container, so the container would crash.

### Solution
Fix the `volumes` parameter in the `docker-compose.yml` file for the Client that had an incorrect filepath. 

### Testing
This was tested by cleaning the folder of all `node_modules` and spinning up the containers to make sure the site still loaded.

### Notes
Now, we don't need to have any `node_modules` installed locally.