### PR TITLE
React Hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Database config
 server/config.js
 
+# VS Code
+.vscode/
+
 # Logs
 logs
 *.log

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import {
   BrowserRouter as Router,
   Switch,
@@ -12,19 +12,18 @@ import {
   Button
 } from '@material-ui/core';
 import MenuIcon from '@material-ui/icons/Menu';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import './App.css';
 
 import Dashboard from './pages/Dashboard';
 import TodoList from './pages/TodoList';
 
-
-const styles = theme => ({
+const useStyles = makeStyles({
   root: {
     flexGrow: 1
   },
   menuButton: {
-    marginRight: theme.spacing(2)
+    marginRight: 2
   },
   title: {
     flexGrow: 1,
@@ -32,39 +31,36 @@ const styles = theme => ({
   },
   body: {
     textAlign: 'center'
-  }
+  },
 });
-class App extends Component {
-  render() {
-    const { classes } = this.props;
-    return (
-      <Router>
-        <AppBar className={classes.root} position="static">
-          <Toolbar>
-            <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="menu">
-              <MenuIcon />
-            </IconButton>
-            <Typography variant="h6" className={classes.title} onClick={() => {window.location.assign('/')}}>
-              Day in Review
-            </Typography>
-            <Button color="inherit">Login</Button>
-          </Toolbar>
-        </AppBar>
-        {/* Main Body */}
-        <div className={classes.body}>
-          {/* Pages */}
-          <Switch>
-            <Route exact path="/">
-              <Dashboard />
-            </Route>
-            <Route exact path="/todo">
-              <TodoList />
-            </Route>
-          </Switch>
-        </div>
-      </Router>
-    );
-  }
-}
 
-export default withStyles(styles)(App);
+export default function App(props) {
+  const classes = useStyles(props);
+  return (
+    <Router>
+      <AppBar className={classes.root} position="static">
+        <Toolbar>
+          <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="menu">
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" className={classes.title} onClick={() => {window.location.assign('/')}}>
+            Day in Review
+          </Typography>
+          <Button color="inherit">Login</Button>
+        </Toolbar>
+      </AppBar>
+      {/* Main Body */}
+      <div className={classes.body}>
+        {/* Pages */}
+        <Switch>
+          <Route exact path="/">
+            <Dashboard />
+          </Route>
+          <Route exact path="/todo">
+            <TodoList />
+          </Route>
+        </Switch>
+      </div>
+    </Router>
+  );
+}

--- a/client/src/components/Todo.js
+++ b/client/src/components/Todo.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import './Todo.css';
 
 import {
@@ -8,10 +8,10 @@ import {
   IconButton
 } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
 
-const styles = theme => ({
+const useStyles = makeStyles({
   root: {
     cursor: 'pointer',
   },
@@ -19,7 +19,8 @@ const styles = theme => ({
     textDecoration: 'line-through',
   }
 });
-class Todo extends Component {
+
+export default function Todo(props) {
   /**
    * Properties:
    * 
@@ -30,26 +31,22 @@ class Todo extends Component {
    * delete: function to delete from database
    * update: function to update todo
    */
-  render() {
-    const { classes } = this.props;
-    return (
-      <ListItem
-        button
-        className={classes.root}
-        onClick={e => this.props.update(e, this.props.id)}
-      >
-        <ListItemText
-          className={this.props.completed ? classes.completed : null}
-          primary={this.props.task}
-        />
-        <ListItemSecondaryAction>
-          <IconButton edge="end" aria-label="delete" onClick={e => this.props.delete(e, this.props.id)}>
-            <DeleteIcon />
-          </IconButton>
-        </ListItemSecondaryAction>
-      </ListItem>
-    );
-  }
+  const classes = useStyles(props);
+  return (
+    <ListItem
+      button
+      className={classes.root}
+      onClick={e => this.props.update(e, this.props.id)}
+    >
+      <ListItemText
+        className={this.props.completed ? classes.completed : null}
+        primary={this.props.task}
+      />
+      <ListItemSecondaryAction>
+        <IconButton edge="end" aria-label="delete" onClick={e => this.props.delete(e, this.props.id)}>
+          <DeleteIcon />
+        </IconButton>
+      </ListItemSecondaryAction>
+    </ListItem>
+  );
 }
-
-export default withStyles(styles)(Todo);

--- a/client/src/components/Todo.js
+++ b/client/src/components/Todo.js
@@ -36,14 +36,14 @@ export default function Todo(props) {
     <ListItem
       button
       className={classes.root}
-      onClick={e => this.props.update(e, this.props.id)}
+      onClick={e => props.update(e, props.id)}
     >
       <ListItemText
-        className={this.props.completed ? classes.completed : null}
-        primary={this.props.task}
+        className={props.completed ? classes.completed : null}
+        primary={props.task}
       />
       <ListItemSecondaryAction>
-        <IconButton edge="end" aria-label="delete" onClick={e => this.props.delete(e, this.props.id)}>
+        <IconButton edge="end" aria-label="delete" onClick={e => props.delete(e, props.id)}>
           <DeleteIcon />
         </IconButton>
       </ListItemSecondaryAction>

--- a/client/src/components/Widget.js
+++ b/client/src/components/Widget.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import './Widget.css';
 import {
   Card,
@@ -8,10 +8,10 @@ import {
   Typography,
   Grid
 } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
 
-const styles = theme => ({
+const useStyles = makeStyles({
   root: {
   },
   media: {
@@ -19,50 +19,46 @@ const styles = theme => ({
   }
 });
 
-class Widget extends Component {
-  render() {
-    const pageLinks = {
-      "todo": "/todo",
-    };
-    const cardSize = {
-      "small": {
-        "xs": 12,
-        "sm": 6,
-        "md": 3
-      },
-      "medium": {
-        "xs": 12,
-        "sm": 6,
-        "md": 6
-      },
-      "large": {
-        "xs": 12,
-        "sm": 12,
-        "md": 12
-      }
-    };
-    const { classes } = this.props;
+export default function Widget(props) {
+  const pageLinks = {
+    "todo": "/todo",
+  };
+  const cardSize = {
+    "small": {
+      "xs": 12,
+      "sm": 6,
+      "md": 3
+    },
+    "medium": {
+      "xs": 12,
+      "sm": 6,
+      "md": 6
+    },
+    "large": {
+      "xs": 12,
+      "sm": 12,
+      "md": 12
+    }
+  };
+  const classes = useStyles(props);
 
-    return (
-      <Grid item xs={cardSize[this.props.size]["xs"]} sm={cardSize[this.props.size]["sm"]} md={cardSize[this.props.size]["md"]}>
-        <Card className={classes.root}>
-          <CardActionArea onClick={() => {window.location.assign(pageLinks[this.props.widget])}}>
-            <CardMedia
-              className={classes.media}
-            />
-            <CardContent>
-              <Typography variant="h5">
-                {this.props.name}
-              </Typography>
-              <Typography>
-                Filler text here for now
-              </Typography>
-            </CardContent>
-          </CardActionArea>
-        </Card>
-      </Grid>
-    );
-  }
+  return (
+    <Grid item xs={cardSize[props.size]["xs"]} sm={cardSize[props.size]["sm"]} md={cardSize[props.size]["md"]}>
+      <Card className={classes.root}>
+        <CardActionArea onClick={() => {window.location.assign(pageLinks[props.widget])}}>
+          <CardMedia
+            className={classes.media}
+          />
+          <CardContent>
+            <Typography variant="h5">
+              {props.name}
+            </Typography>
+            <Typography>
+              Filler text here for now
+            </Typography>
+          </CardContent>
+        </CardActionArea>
+      </Card>
+    </Grid>
+  );
 }
-
-export default withStyles(styles)(Widget);

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -1,29 +1,27 @@
-import React, { Component } from 'react';
+import React from 'react';
 import './Dashboard.css';
 import {
   Grid
 } from '@material-ui/core'
 import Widget from '../components/Widget'
 
-export default class Dashboard extends Component {
-  render() {
-    // Create widgets
-    const widgets = [];
-    for (let i = 0; i < 6; i++) {
-      widgets.push(<Widget name="Small Widget" size="small" widget="todo" />)
-    }
-    for (let i = 0; i < 4; i++) {
-      widgets.push(<Widget name="Medium Widget" size="medium" />)
-    }
-    for (let i = 0; i < 2; i++) {
-      widgets.push(<Widget name="Large Widget" size="large" />)
-    }
-
-    return (
-      // Row of Widgets
-      <Grid container spacing={2}>
-        {widgets}
-      </Grid>
-    );
+export default function Dashboard() {
+  // Create widgets
+  const widgets = [];
+  for (let i = 0; i < 6; i++) {
+    widgets.push(<Widget name="Small Widget" size="small" widget="todo" />)
   }
+  for (let i = 0; i < 4; i++) {
+    widgets.push(<Widget name="Medium Widget" size="medium" />)
+  }
+  for (let i = 0; i < 2; i++) {
+    widgets.push(<Widget name="Large Widget" size="large" />)
+  }
+
+  return (
+    // Row of Widgets
+    <Grid container spacing={2}>
+      {widgets}
+    </Grid>
+  );
 }

--- a/client/src/pages/TodoList.js
+++ b/client/src/pages/TodoList.js
@@ -19,7 +19,7 @@ export default function TodoList(props) {
       setTodos(todos);
     }
     fetchTodoAndSetTodos();
-  })
+  }, [])
 
   const createTodo = async e => {
     e.preventDefault()


### PR DESCRIPTION
### Problem
React components are relatively outdated and are annoying to use because of convoluted state variables and functions like `componentDidMount`.

### Solution
This PR introduces [hooks](https://reactjs.org/docs/hooks-intro.html), which are much more widely used than components. A few steps were taken to convert the components to hooks.

1. Change class definitions to `export default function foo(props)` and remove `render` methods
2. Use `makeStyles` instead of `withStyles`
3. Remove all instances of `this`
4. Replace all constructors with `const [state, setState] = useState("any state data goes here")` and use `setState("any state data goes here")` to modify state
5. Change `componentDidMount` to `useEffect`

### Testing
I tested these changes by making sure all of the components still rendered and that the functionality was still there. @JimothyGreene when you get a chance, double check that `TodoList` is still functioning as expected because that's where I made the most alterations since I had to change a bunch of `setState` functions.

### Notes
I referenced a [Medium post](https://olinations.medium.com/10-steps-to-convert-a-react-class-component-to-a-functional-component-with-hooks-ab198e0fa139) to help me figure out how to make these changes.

Closes #26 