### PR TITLE
User Login Frontend

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -47,8 +47,23 @@ export default function App(props) {
     setAuthToken(token);
   }
 
+  const clearToken = () => {
+    localStorage.removeItem('token');
+    setAuthToken(null);
+  }
+
+  // Login/Logout
+  const loginLogout = () => {
+    if (authToken) {
+      // Logout
+      clearToken();
+    } else {
+      window.location.assign('/login');
+    }
+  }
+
   return (
-    <AuthContext.Provider value={{ authToken, setAuthToken: setToken }}>
+    <AuthContext.Provider value={{ authToken, setAuthToken: setToken, clearAuthToken: clearToken }}>
       <Router>
         <AppBar className={classes.root} position="static">
           <Toolbar>
@@ -58,7 +73,7 @@ export default function App(props) {
             <Typography variant="h6" className={classes.title} onClick={() => {window.location.assign('/')}}>
               Day in Review
             </Typography>
-            <Button color="inherit">Login</Button>
+            <Button color="inherit" onClick={ loginLogout }>{ authToken ? "Logout" : "Login" }</Button>
           </Toolbar>
         </AppBar>
         {/* Main Body */}

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   BrowserRouter as Router,
   Switch,
   Route,
 } from "react-router-dom";
+import PrivateRoute from './PrivateRoute';
 import {
   AppBar,
   Toolbar,
@@ -14,9 +15,11 @@ import {
 import MenuIcon from '@material-ui/icons/Menu';
 import { makeStyles } from '@material-ui/core/styles';
 import './App.css';
+import { AuthContext } from './context/auth';
 
 import Dashboard from './pages/Dashboard';
 import TodoList from './pages/TodoList';
+import Login from './pages/Login';
 
 const useStyles = makeStyles({
   root: {
@@ -36,31 +39,38 @@ const useStyles = makeStyles({
 
 export default function App(props) {
   const classes = useStyles(props);
+  const existingToken = JSON.parse(localStorage.getItem("token"));
+  const [authToken, setAuthToken] = useState(existingToken);
+
+  const setToken = (token) => {
+    localStorage.setItem('token', JSON.stringify(token));
+    setAuthToken(token);
+  }
+
   return (
-    <Router>
-      <AppBar className={classes.root} position="static">
-        <Toolbar>
-          <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="menu">
-            <MenuIcon />
-          </IconButton>
-          <Typography variant="h6" className={classes.title} onClick={() => {window.location.assign('/')}}>
-            Day in Review
-          </Typography>
-          <Button color="inherit">Login</Button>
-        </Toolbar>
-      </AppBar>
-      {/* Main Body */}
-      <div className={classes.body}>
-        {/* Pages */}
-        <Switch>
-          <Route exact path="/">
-            <Dashboard />
-          </Route>
-          <Route exact path="/todo">
-            <TodoList />
-          </Route>
-        </Switch>
-      </div>
-    </Router>
+    <AuthContext.Provider value={{ authToken, setAuthToken: setToken }}>
+      <Router>
+        <AppBar className={classes.root} position="static">
+          <Toolbar>
+            <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="menu">
+              <MenuIcon />
+            </IconButton>
+            <Typography variant="h6" className={classes.title} onClick={() => {window.location.assign('/')}}>
+              Day in Review
+            </Typography>
+            <Button color="inherit">Login</Button>
+          </Toolbar>
+        </AppBar>
+        {/* Main Body */}
+        <div className={classes.body}>
+          {/* Pages */}
+          <Switch>
+            <Route exact path="/login" component={Login} />
+            <PrivateRoute exact path={["/", "/dashboard"]} component={Dashboard} />
+            <PrivateRoute exact path="/todo" component={TodoList} />
+          </Switch>
+        </div>
+      </Router>
+    </AuthContext.Provider>
   );
 }

--- a/client/src/PrivateRoute.js
+++ b/client/src/PrivateRoute.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import { useAuth } from './context/auth';
+
+export default function PrivateRoute({ component: Component, ...rest}) {
+  const { authToken } = useAuth();
+  
+  return (
+    <Route
+      {...rest}
+      render={props =>
+        authToken ? (
+          <Component {...props} />
+        ) : (
+          <Redirect to={{ pathname: "/login", state: { referer: props.location } }}/>
+        )
+      }
+    />
+  );
+}

--- a/client/src/context/auth.js
+++ b/client/src/context/auth.js
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+export const AuthContext = createContext();
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Redirect } from 'react-router-dom';
+import { TextField, Button } from '@material-ui/core';
+import LoginAPI from './LoginAPI';
+import { useAuth } from '../context/auth';
+
+export default function Login(props) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const { setAuthToken } = useAuth();
+  const referer = props.location.state.referer || '/';
+
+  const loginUser = async (e) => {
+    e.preventDefault();
+    const token = await LoginAPI.login(email, password);
+    if (token) {
+      console.log(`token: ${token}`);
+      setAuthToken(token);
+      setIsLoggedIn(true);
+    }
+  }
+
+  if (isLoggedIn) {
+    return <Redirect to={referer} />
+  }
+
+  return (
+    <form onSubmit={e => loginUser(e)}>
+      <TextField
+        id="standard-basic"
+        label="Email"
+        onChange={({ target }) => setEmail(target.value)}
+      />
+      <TextField
+        id="standard-basic"
+        label="Password"
+        onChange={({ target }) => setPassword(target.value)}
+      />
+      <Button type="submit" variant="contained">
+          Login
+      </Button>
+    </form>
+  );
+}

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -7,9 +7,15 @@ import { useAuth } from '../context/auth';
 export default function Login(props) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const { setAuthToken } = useAuth();
-  const referer = props.location.state.referer || '/';
+  const { authToken, setAuthToken } = useAuth();
+  const [isLoggedIn, setIsLoggedIn] = useState(!!authToken);
+  
+  let referer;
+  try {
+    referer = props.location.state.referer;
+  } catch (err) {
+    referer = '/';
+  }
 
   const loginUser = async (e) => {
     e.preventDefault();

--- a/client/src/pages/LoginAPI.js
+++ b/client/src/pages/LoginAPI.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const API_URL = "http://localhost:5000/api/users/login";
+
+async function login(email, password) {
+  const { data: res } = await axios.post(API_URL, {
+    email,
+    password
+  });
+  if (res.success) {
+    return res.token;
+  }
+}
+
+export default { login };


### PR DESCRIPTION
### Problem
Users could not access the login functionality, so we could not have Private endpoints that only authenticated users could access. Also, the React frontend had no way of keeping track of a token once it received one from the server.

### Solution
Using the React Context API and `localStorage`, we can keep track of a token on the client side for authentication. The entire App is wrapped in an AuthContext Provider that is tied to **states** for the App component. Any child component can modify the state, which then modifies the **context**. Once the context is modified, the token is kept in localStorage and is refreshed anytime the App component refreshes. This way, upon page refresh or even browser restart, the token is still available. 

### Testing
This was tested by making the Dashboard and Todo pages private. Then, I could only access those pages after logging in. If I was not logged in, I would be redirected to the login page.

### Notes
This does not add support for user registration, but the infrastructure is now in place. Also, the login form looks terrible, but it does the trick. I'd like to get this part approved first, then in a separate PR, I can make the form nicer and add a registration form to go along with it.

Closes #27 