### PR TITLE
User-Specific Todo Items

### DIFF
--- a/client/src/API.js
+++ b/client/src/API.js
@@ -1,0 +1,34 @@
+import axios from 'axios';
+
+const API = axios.create({
+  baseURL: 'http://localhost:5000/api',
+});
+
+API.interceptors.request.use(
+  (config) => {
+    const token = JSON.parse(localStorage.getItem('token'));
+
+    if (token) {
+      config.headers.common["Authorization"] = `${token}`;
+    } else {
+      delete API.defaults.headers.common.Authorization;
+    }
+    return config;
+  }, (err) => {
+    console.log(err);
+  }
+);
+
+API.interceptors.response.use(
+  (res) => {
+    return res;
+  }, (err) => {
+    if (err.response.status === 401) {
+      // Unauthorized -> user must log in again
+      localStorage.removeItem('token');
+      location.reload();
+    } // TODO: Add handling for other error codes here
+  }
+);
+
+export default API;

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -27,7 +27,6 @@ export default function Login(props) {
     }
     const res = await LoginAPI.login(email, password);
     if (res.success) {
-      console.log(`token: ${res.data}`);
       setAuthToken(res.data);
       setIsLoggedIn(true);
     } else {
@@ -54,7 +53,6 @@ export default function Login(props) {
   const classes = useStyles();
   
   if (isLoggedIn) {
-    console.log(referer);
     return <Redirect to={referer} />
   }
   

--- a/client/src/pages/LoginAPI.js
+++ b/client/src/pages/LoginAPI.js
@@ -1,10 +1,10 @@
-import axios from 'axios';
+import API from '../API';
 
-const API_URL = "http://localhost:5000/api/users/login";
+const API_URL = "/users/login";
 
 async function login(email, password) {
   try {
-    const { data: res } = await axios.post(API_URL, {
+    const { data: res } = await API.post(API_URL, {
       email,
       password
     });

--- a/client/src/pages/RegisterAPI.js
+++ b/client/src/pages/RegisterAPI.js
@@ -1,10 +1,10 @@
-import axios from 'axios';
+import API from '../API';
 
-const API_URL = "http://localhost:5000/api/users/register";
+const API_URL = "/users/register";
 
 async function register(name, email, password, password2) {
   try {
-    const { data: user} = await axios.post(API_URL, {
+    const { data: user} = await API.post(API_URL, {
       name,
       email,
       password,

--- a/client/src/pages/TodoListAPI.js
+++ b/client/src/pages/TodoListAPI.js
@@ -1,26 +1,26 @@
-import axios from "axios"
+import API from "../API";
 
-const API_URL = "http://localhost:5000/api/todos/"
+const API_URL = "/todos/"
 
 async function createTodo(task) {
-  const { data: newTodo } = await axios.post(API_URL, {
+  const { data: newTodo } = await API.post(API_URL, {
     task,
   })
   return newTodo
 }
 
 async function deleteTodo(id) {
-  const message = await axios.delete(`${API_URL}${id}`)
+  const message = await API.delete(`${API_URL}${id}`)
   return message
 }
 
 async function updateTodo(id, payload) {
-  const { data: newTodo } = await axios.put(`${API_URL}${id}`, payload)
+  const { data: newTodo } = await API.put(`${API_URL}${id}`, payload)
   return newTodo
 }
 
 async function getAllTodos() {
-  const { data: todos } = await axios.get(API_URL)
+  const { data: todos } = await API.get(API_URL)
   return todos
 }
 

--- a/server/models/todo.js
+++ b/server/models/todo.js
@@ -1,11 +1,11 @@
 const mongoose = require("mongoose"); // requiring the mongoose package
+const Schema = mongoose.Schema;
 
-const todoSchema = new mongoose.Schema({
+const todoSchema = new Schema({
   // creating a schema for todo
   task: {
     // field1: task
     type: String, // task is a string
-    unique: true, // it has to be unique
     required: true, // it is required
   },
   completed: {
@@ -13,6 +13,10 @@ const todoSchema = new mongoose.Schema({
     type: Boolean, // it is a boolean
     default: false, // the default is false
   },
+  user_id: {
+    type: Schema.Types.ObjectId,
+    required: true,
+  }
 });
 
 const todoModel = mongoose.model("Todo", todoSchema); // creating the model from the schema

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
 
-const userSchema = new mongoose.Schema({
+const userSchema = new Schema({
 	name: {
     type: String,
     required: true

--- a/server/passport.js
+++ b/server/passport.js
@@ -1,5 +1,3 @@
-const { modelName } = require("./models/user");
-
 const JwtStrategy = require("passport-jwt").Strategy;
 const ExtractJwt = require("passport-jwt").ExtractJwt;
 const User = require("./models").User;

--- a/server/routes/todos.js
+++ b/server/routes/todos.js
@@ -9,7 +9,7 @@ const router = express.Router();
  */
 router.post("/", async (req, res, next) => {
   try {
-    const todo = await Todo.create(req.body);
+    const todo = await Todo.create({...req.body, user_id: req.user.id});
     return res.status(200).json(todo);
   } catch (err) {
     next({ status: 400, message: "Failed to create todo" });
@@ -23,7 +23,7 @@ router.post("/", async (req, res, next) => {
  */
 router.get("/", async (req, res, next) => {
   try {
-    const todos = await Todo.find({});
+    const todos = await Todo.find({user_id: req.user._id});
     return res.status(200).json(todos);
   } catch (err) {
     console.log(err);

--- a/server/server.js
+++ b/server/server.js
@@ -24,7 +24,7 @@ app.use(passport.initialize());
 require("./passport")(passport);  // Configures passport
 
 app.use("/api/users", users);
-app.use("/api/todos", todos);
+app.use("/api/todos", passport.authenticate('jwt', { session: false }), todos);
 
 app.use((err, req, res, next) => {
   return res.status(err.status || 400).json({


### PR DESCRIPTION
### Problem
Every user could see every todo item that was created. This was not personalized, nor does it make use of the individual user profiles. 

### Solution
Associate each todo item with a specific user in the database. Now, when creating a new todo item, the `user_id` is given by the `passport` so long as the request has the correct token in the Authorization Header. When retrieving todo items, the same idea is applied. The `todo` API is protected by the `passport` authentication. Without a valid, nonexpired token in the header of the request, the server will give back a 401 status, which will prompt the client to log the user out and ask them to log back in.

### Testing
This was tested by creating new todo items as one user and logging in as another user to ensure that they did not show up. The `passport` protection was tested by trying to access the routes without a proper token in the header, and the correct response was given back.

### Notes
This PR also introduces a better way to make API calls with axios. There is a centralized API instance that provides the base URL and the functionality for grabbing the token from localStorage. It also has a handler for responses, meaning that we can handle each response error status in one place and it will apply to all of our API requests. Currently, we only handle for 401, but we can easly handle for other status codes in the future now.

Closes #15 