### PR TITLE
Dashboard Widget Cards

### DIFF
--- a/client/src/components/Widget.js
+++ b/client/src/components/Widget.js
@@ -10,51 +10,49 @@ import {
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
-
 const useStyles = makeStyles({
   root: {
+    margin: '0.4rem',
+    borderRadius: '10px',
+    textAlign: 'center'
   },
   media: {
-    height: 140
-  }
+    height: '20vh'
+  },
+  content: {
+    height: '12vh',
+    padding: '2rem',
+    display: 'flex',
+    flexDirection: 'column'
+  },
 });
 
 export default function Widget(props) {
   const pageLinks = {
     "todo": "/todo",
+    "email": "/email",
+    "summarizer": "/summarizer"
   };
   const cardSize = {
-    "small": {
-      "xs": 12,
-      "sm": 6,
-      "md": 3
-    },
-    "medium": {
-      "xs": 12,
-      "sm": 6,
-      "md": 6
-    },
-    "large": {
-      "xs": 12,
-      "sm": 12,
-      "md": 12
-    }
+    "xs": 12,
+    "sm": 6,
+    "md": 4
   };
   const classes = useStyles(props);
 
   return (
-    <Grid item xs={cardSize[props.size]["xs"]} sm={cardSize[props.size]["sm"]} md={cardSize[props.size]["md"]}>
+    <Grid item xs={cardSize["xs"]} sm={cardSize["sm"]} md={cardSize["md"]}>
       <Card className={classes.root}>
-        <CardActionArea onClick={() => {window.location.assign(pageLinks[props.widget])}}>
-          <CardMedia
-            className={classes.media}
-          />
-          <CardContent>
-            <Typography variant="h5">
+        <CardActionArea onClick={() => { window.location.assign(pageLinks[props.widget]) }}>
+          <CardMedia id="card-media" className={classes.media}>
+            {props.icon}
+          </CardMedia>
+          <CardContent className={classes.content}>
+            <Typography variant="h3">
               {props.name}
             </Typography>
-            <Typography>
-              Filler text here for now
+            <Typography variant="h5">
+              {props.description}
             </Typography>
           </CardContent>
         </CardActionArea>

--- a/client/src/components/Widget.js
+++ b/client/src/components/Widget.js
@@ -13,14 +13,18 @@ import { makeStyles } from '@material-ui/core/styles';
 const useStyles = makeStyles({
   root: {
     margin: '0.4rem',
-    borderRadius: '10px',
-    textAlign: 'center'
+    borderRadius: '18px',
+    border: '4px solid white',
+    '&:hover': {
+      transition: 'all 0.2s ease-out',
+      border: '4px solid #00838d',
+    },
   },
   media: {
     height: '20vh'
   },
   content: {
-    height: '12vh',
+    height: '14vh',
     padding: '2rem',
     display: 'flex',
     flexDirection: 'column'

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -3,20 +3,28 @@ import './Dashboard.scss';
 import {
   Grid
 } from '@material-ui/core'
+import ListAltOutlinedIcon from '@material-ui/icons/ListAltOutlined';
+import EmailOutlinedIcon from '@material-ui/icons/EmailOutlined';
+import DescriptionOutlinedIcon from '@material-ui/icons/DescriptionOutlined';
 import Widget from '../components/Widget'
 
+
 export default function Dashboard() {
+  const descriptions = {
+    "todo": "A simple to-do list",
+    "email": "AI-powered email summaries delivered straight to your inbox",
+    "summarizer": "Get summaries of all sorts of documents"
+  }
+
   // Create widgets
   const widgets = [];
-  for (let i = 0; i < 6; i++) {
-    widgets.push(<Widget name="Small Widget" size="small" widget="todo" />)
-  }
-  for (let i = 0; i < 4; i++) {
-    widgets.push(<Widget name="Medium Widget" size="medium" />)
-  }
-  for (let i = 0; i < 2; i++) {
-    widgets.push(<Widget name="Large Widget" size="large" />)
-  }
+
+  widgets.push(<Widget name="To-do" description={descriptions.todo} widget="todo" icon={<ListAltOutlinedIcon style={{ fontSize: 180, color: 'green' }}/>} />);
+  widgets.push(<Widget name="Email" description={descriptions.email} widget="email" icon={<EmailOutlinedIcon style={{ fontSize: 180, color: 'blue' }}/>} />);
+  widgets.push(<Widget name="Summarizer" description={descriptions.summarizer} widget="summarizer" icon={<DescriptionOutlinedIcon style={{ fontSize: 180, color: 'red' }}/>} />);
+  widgets.push(<Widget name="To-do" description={descriptions.todo} widget="todo" icon={<ListAltOutlinedIcon style={{ fontSize: 180, color: 'green' }}/>} />);
+  widgets.push(<Widget name="To-do" description={descriptions.todo} widget="todo" icon={<ListAltOutlinedIcon style={{ fontSize: 180, color: 'green' }}/>} />);
+  widgets.push(<Widget name="To-do" description={descriptions.todo} widget="todo" icon={<ListAltOutlinedIcon style={{ fontSize: 180, color: 'green' }}/>} />);
 
   return (
     // Row of Widgets


### PR DESCRIPTION
### Problem
We needed to create a dashboard with all of the main widgets we plan on implementing.

### Solution
This PR maintains the original grid of cards idea except it uses a flexbox to make the cards responsive. The dashboard currently has room for 6 widgets which we will probably end up filling up. All of these widgets have `name`, `description`, and `icon` properties passed to them and we can eventually create custom SVGs for our icons to mimic the Google Suite look.

### Testing
This was tested by observing how cards behave at different page sizes. Generally, the cards will shrink and scale as a function of the page height and width. Text doesn't currently scale but I didn't think it was a huge problem.

Closes #38 
Closes #5 