### PR TITLE
Adds widget icon to dashboard for the Grades widget

### DIFF
--- a/client/src/components/Widget.js
+++ b/client/src/components/Widget.js
@@ -35,7 +35,8 @@ export default function Widget(props) {
   const pageLinks = {
     "todo": "/todo",
     "email": "/email",
-    "summarizer": "/summarizer"
+    "summarizer": "/summarizer",
+    "grades": "/grades",
   };
   const cardSize = {
     "xs": 12,

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -6,6 +6,7 @@ import {
 import ListAltOutlinedIcon from '@material-ui/icons/ListAltOutlined';
 import EmailOutlinedIcon from '@material-ui/icons/EmailOutlined';
 import DescriptionOutlinedIcon from '@material-ui/icons/DescriptionOutlined';
+import SchoolOutlinedIcon from '@material-ui/icons/SchoolOutlined';
 import Widget from '../components/Widget'
 
 
@@ -13,7 +14,8 @@ export default function Dashboard() {
   const descriptions = {
     "todo": "A simple to-do list",
     "email": "AI-powered email summaries delivered straight to your inbox",
-    "summarizer": "Get summaries of all sorts of documents"
+    "summarizer": "Get summaries of all sorts of documents",
+    "grades": "Track your course assignments, grades, and GPA",
   }
 
   // Create widgets
@@ -22,7 +24,7 @@ export default function Dashboard() {
   widgets.push(<Widget name="To-do" description={descriptions.todo} widget="todo" icon={<ListAltOutlinedIcon style={{ fontSize: 180, color: 'green' }}/>} />);
   widgets.push(<Widget name="Email" description={descriptions.email} widget="email" icon={<EmailOutlinedIcon style={{ fontSize: 180, color: 'blue' }}/>} />);
   widgets.push(<Widget name="Summarizer" description={descriptions.summarizer} widget="summarizer" icon={<DescriptionOutlinedIcon style={{ fontSize: 180, color: 'red' }}/>} />);
-  widgets.push(<Widget name="To-do" description={descriptions.todo} widget="todo" icon={<ListAltOutlinedIcon style={{ fontSize: 180, color: 'green' }}/>} />);
+  widgets.push(<Widget name="Grades" description={descriptions.grades} widget="grades" icon={<SchoolOutlinedIcon style={{ fontSize: 180, color: 'orange' }}/>} />);
   widgets.push(<Widget name="To-do" description={descriptions.todo} widget="todo" icon={<ListAltOutlinedIcon style={{ fontSize: 180, color: 'green' }}/>} />);
   widgets.push(<Widget name="To-do" description={descriptions.todo} widget="todo" icon={<ListAltOutlinedIcon style={{ fontSize: 180, color: 'green' }}/>} />);
 


### PR DESCRIPTION
### Problem
There was no way to access the grades widget without manually typing the URL

### Solution
Add a widget icon to the dashboard page that links to the grades widget. Using the existing infrastructure, I only needed to add a description, change the icon, and add a link option in the `Widget.js` file. 

### Testing
I tested this by loading up the dashboard page and clicking the Grades icon. It then took me to the widget correctly where everything loaded properly.

Closes #47 