### PR TITLE
Grades Edit/Delete

### DIFF
--- a/client/src/components/DialogForm.js
+++ b/client/src/components/DialogForm.js
@@ -43,7 +43,7 @@ export default function DialogForm(props) {
         <Button onClick={handleClose} color="primary">
           Cancel
         </Button>
-        <Button onClick={handleSubmit} color="primary">
+        <Button onClick={handleSubmit} color={props.actionType === 'delete' ? "secondary" : "primary"}>
           { submit[props.actionType] }
         </Button>
       </DialogActions>

--- a/client/src/components/DialogForm.js
+++ b/client/src/components/DialogForm.js
@@ -3,6 +3,18 @@ import React, { useState, cloneElement } from 'react';
 import { Dialog, DialogTitle, DialogContent, DialogContentText,
           DialogActions, Button } from '@material-ui/core';
 
+const titles = {
+  add: 'Add New Item',
+  edit: 'Update Item',
+  delete: 'Delete Item',
+}
+
+const submit = {
+  add: 'Add',
+  edit: 'Update',
+  delete: 'Delete',
+}
+
 export default function DialogForm(props) {
   const [submitted, setSubmitted] = useState(false);
   
@@ -20,7 +32,7 @@ export default function DialogForm(props) {
 
   return (
     <Dialog open={ props.open } onClose={handleClose}>
-      <DialogTitle>{ props.title }</DialogTitle>
+      <DialogTitle>{ titles[props.actionType] }</DialogTitle>
       <DialogContent>
         <DialogContentText>
           { props.content }
@@ -32,7 +44,7 @@ export default function DialogForm(props) {
           Cancel
         </Button>
         <Button onClick={handleSubmit} color="primary">
-          Add
+          { submit[props.actionType] }
         </Button>
       </DialogActions>
     </Dialog>

--- a/client/src/components/grades/AssignmentForm.js
+++ b/client/src/components/grades/AssignmentForm.js
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+
+import { TableRow, TableCell, TextField, Checkbox, Button } from '@material-ui/core';
+import { MuiPickersUtilsProvider, KeyboardDatePicker } from '@material-ui/pickers';
+import DateFnsUtils from '@date-io/date-fns';
+
+import GradesAPI from '../../pages/GradesAPI';
+
+export default function AssignmentForm(props) {
+  const [assignment, setAssignment] = useState(props.current ? props.current.name : "");
+  const [dueDate, setDueDate] = useState(props.current ? new Date(props.current.due_date) : new Date());
+  const [completed, setCompleted] = useState(props.current ? props.current.completed : false);
+  const [grade, setGrade] = useState(props.current ? props.current.grade : '');
+
+  const addAssignment = async () => {
+    const newAssignment = await GradesAPI.createAssignment({
+      name: assignment,
+      due_date: dueDate,
+      completed: completed,
+      grade: grade,
+      type_id: props.type._id,
+    });
+    props.setAssignments((state) => ({
+      ...state,
+      [props.type.name]: [
+        ...state[props.type.name],
+        newAssignment,
+      ],
+    }));
+
+    // Clear form
+    setAssignment("");
+    setDueDate(new Date());
+    setCompleted(false);
+    setGrade(null);
+  }
+
+  const updateAssignment = async () => {
+    const updatedAssignment = await GradesAPI.updateAssignment(props.current._id, {
+      name: assignment,
+      due_date: dueDate,
+      completed: completed,
+      grade: grade,
+      type_id: props.type._id,
+    });
+    props.setAssignments((state) => ({
+      ...state,
+      [props.type.name]: state[props.type.name].map(assignment => (
+        assignment._id === props.current._id ? updatedAssignment : assignment
+      ))
+    }));
+    props.setAssignmentEdit(false);
+  }
+
+  const handleSubmit = async () => {
+    if (props.current) {
+      updateAssignment();
+    } else {
+      addAssignment();
+    }
+  }
+
+  return  (
+    <TableRow>
+      <TableCell component="th" scope="row">
+        <TextField
+          margin="dense"
+          value={assignment}
+          label="Assignment Name"
+          fullWidth
+          size="small"
+          onChange={(e) => {setAssignment(e.target.value)}}
+        />
+      </TableCell>
+      <TableCell align="right">
+        <MuiPickersUtilsProvider utils={DateFnsUtils}>
+          <KeyboardDatePicker
+            disableToolbar
+            variant="inline"
+            format="MM/dd/yyyy"
+            margin="normal"
+            label="Due Date"
+            value={dueDate}
+            onChange={(date) => {setDueDate(date)}}
+          />
+        </MuiPickersUtilsProvider>
+      </TableCell>
+      <TableCell align="right">
+        <Checkbox
+          color="primary"
+          checked={completed}
+          onChange={(e) => {setCompleted(!completed)}}
+        />
+      </TableCell>
+      <TableCell align="right">
+        <TextField
+          margin="dense"
+          value={grade || ''}
+          label="Grade"
+          size="small"
+          disabled={!completed}
+          onChange={(e) => {setGrade(e.target.value)}}
+        />
+      </TableCell>
+      <TableCell align="right">
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleSubmit}
+        >
+          {props.current ? "Update" : "Add"}
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/client/src/components/grades/AssignmentTypeForm.js
+++ b/client/src/components/grades/AssignmentTypeForm.js
@@ -11,11 +11,11 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function AddAssignmentTypeForm(props) {
+export default function AssignmentTypeForm(props) {
   const classes = useStyles();
-  const [assignmentType, setAssignmentType] = useState("");
-  const [weight, setWeight] = useState(0.0);
-  const [drops, setDrops] = useState(0);
+  const [assignmentType, setAssignmentType] = useState(props.current ? props.current.name : "");
+  const [weight, setWeight] = useState(props.current ? props.current.weight*100 : 0.0);
+  const [drops, setDrops] = useState(props.current ? props.current.drops : 0);
 
   const addAssignmentType = async () => {
     const newAssignmentType = await GradesAPI.createAssignmentType({
@@ -24,15 +24,31 @@ export default function AddAssignmentTypeForm(props) {
       drops: drops,
       course_id: props.course._id,
     });
-    props.setAssignmentTypes((state, props) => ([
+    props.setAssignmentTypes((state) => ([
       ...state,
       newAssignmentType,
     ]));
   }
 
+  const updateAssignmentType = async () => {
+    const updatedAssignmentType = await GradesAPI.updateAssignmentType(props.current._id, {
+      name: assignmentType,
+      weight: weight/100,
+      drops: drops,
+      course_id: props.current.course_id,
+    });
+    props.setAssignmentTypes((state) => (state.map(type => (
+      type._id === props.current._id ? updatedAssignmentType : type
+    ))));
+  }
+
   useEffect(() => {
     if (props.submitted) {
-      addAssignmentType();
+      if (props.current) {
+        updateAssignmentType();
+      } else {
+        addAssignmentType();
+      }
       props.setSubmitted(false);
     }
   }, [props.submitted]);
@@ -41,6 +57,7 @@ export default function AddAssignmentTypeForm(props) {
     <div>
       <TextField
         autoFocus
+        value={assignmentType}
         margin="dense"
         label="Assignment Type"
         fullWidth
@@ -49,6 +66,7 @@ export default function AddAssignmentTypeForm(props) {
       <FormControl className={classes.formControl}>
         <Input
           label="Weight"
+          value={weight}
           onChange={(e) => {setWeight(e.target.value)}}
           endAdornment={<InputAdornment position="end">%</InputAdornment>}
         />
@@ -56,8 +74,8 @@ export default function AddAssignmentTypeForm(props) {
       </FormControl>
       <FormControl className={classes.formControl}>
         <Input
-          value={drops}
           label="Drops"
+          value={drops}
           onChange={(e) => {setDrops(e.target.value)}}
         />
         <FormHelperText>Drops</FormHelperText>

--- a/client/src/components/grades/CourseForm.js
+++ b/client/src/components/grades/CourseForm.js
@@ -53,7 +53,7 @@ export default function CourseForm(props) {
       cutoffs: newCutoffs,
       semester_id: courseSemester._id,
     });
-    props.setCourses((state, props) => ({
+    props.setCourses((state) => ({
       ...state,
       [courseSemester.name]: [
         ...state[courseSemester.name],

--- a/client/src/components/grades/DeleteForm.js
+++ b/client/src/components/grades/DeleteForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Typography } from '@material-ui/core';
 
@@ -6,17 +6,43 @@ import GradesAPI from '../../pages/GradesAPI';
 
 export default function DeleteForm(props) {
 
-  const deleteSemester = () => {
+  const deleteSemester = async () => {
 
   }
 
-  const deleteCourse = () => {
+  const deleteCourse = async () => {
+    await GradesAPI.deleteCourse(props.current._id);
+    const semester = props.semesters.find(s => s._id === props.current.semester_id);
+    props.setCourses((state) => ({
+      ...state,
+      [semester.name]: state[semester.name].filter(course => (
+        course._id !== props.current._id
+      )),
+    }));
+  }
+
+  const deleteAssignmentType = async () => {
 
   }
 
-  const deleteAssignmentType = () => {
+  useEffect(() => {
+    if (props.submitted) {
+      switch (props.type) {
+        case 'course':
+          deleteCourse();
+          break;
+        case 'assignment type':
+          break;
+        case 'assignment':
+          break;
+        default:
+          break;
+      }
+      props.setSubmitted(false);
+    }
+  }, [props.submitted]);
 
-  }
+  
 
   return (
     <Typography variant="body1">

--- a/client/src/components/grades/DeleteForm.js
+++ b/client/src/components/grades/DeleteForm.js
@@ -11,8 +11,8 @@ export default function DeleteForm(props) {
     props.setSemesters((state) => (
       state.filter(semester => (
         semester._id !== props.current._id
-      )
-    )));
+      ))
+    ));
   }
 
   const deleteCourse = async () => {
@@ -27,7 +27,12 @@ export default function DeleteForm(props) {
   }
 
   const deleteAssignmentType = async () => {
-
+    await GradesAPI.deleteAssignmentType(props.current._id);
+    props.setAssignmentTypes((state) => (
+      state.filter(type => (
+        type._id !== props.current._id
+      ))
+    ));
   }
 
   useEffect(() => {

--- a/client/src/components/grades/DeleteForm.js
+++ b/client/src/components/grades/DeleteForm.js
@@ -7,7 +7,12 @@ import GradesAPI from '../../pages/GradesAPI';
 export default function DeleteForm(props) {
 
   const deleteSemester = async () => {
-
+    await GradesAPI.deleteSemester(props.current._id);
+    props.setSemesters((state) => (
+      state.filter(semester => (
+        semester._id !== props.current._id
+      )
+    )));
   }
 
   const deleteCourse = async () => {
@@ -28,12 +33,14 @@ export default function DeleteForm(props) {
   useEffect(() => {
     if (props.submitted) {
       switch (props.type) {
+        case 'semester':
+          deleteSemester();
+          break;
         case 'course':
           deleteCourse();
           break;
         case 'assignment type':
-          break;
-        case 'assignment':
+          deleteAssignmentType();
           break;
         default:
           break;

--- a/client/src/components/grades/DeleteForm.js
+++ b/client/src/components/grades/DeleteForm.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { Typography } from '@material-ui/core';
+
+import GradesAPI from '../../pages/GradesAPI';
+
+export default function DeleteForm(props) {
+
+  const deleteSemester = () => {
+
+  }
+
+  const deleteCourse = () => {
+
+  }
+
+  const deleteAssignmentType = () => {
+
+  }
+
+  return (
+    <Typography variant="body1">
+      Are you sure you want to delete { props.current.name }?
+    </Typography>
+  );
+}

--- a/client/src/components/grades/DeleteForm.js
+++ b/client/src/components/grades/DeleteForm.js
@@ -35,6 +35,17 @@ export default function DeleteForm(props) {
     ));
   }
 
+  const deleteAssignment = async () => {
+    await GradesAPI.deleteAssignment(props.current._id);
+    const type = props.assignmentTypes.find(t => t._id === props.current.type_id);
+    props.setAssignments((state) => ({
+      ...state,
+      [type.name]: state[type.name].filter(assignment => (
+        assignment._id !== props.current._id
+      )),
+    }));
+  }
+
   useEffect(() => {
     if (props.submitted) {
       switch (props.type) {
@@ -46,6 +57,9 @@ export default function DeleteForm(props) {
           break;
         case 'assignment type':
           deleteAssignmentType();
+          break;
+        case 'assignment':
+          deleteAssignment();
           break;
         default:
           break;

--- a/client/src/components/grades/GradesTable.js
+++ b/client/src/components/grades/GradesTable.js
@@ -1,14 +1,11 @@
 import React, { useState } from 'react';
 
 import { makeStyles } from '@material-ui/core/styles';
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, TextField, Checkbox, Button, IconButton } from '@material-ui/core';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, IconButton } from '@material-ui/core';
 import DoneIcon from '@material-ui/icons/Done';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
-import { MuiPickersUtilsProvider, KeyboardDatePicker } from '@material-ui/pickers';
-import DateFnsUtils from '@date-io/date-fns';
 
-import GradesAPI from '../../pages/GradesAPI';
-
+import AssignmentForm from './AssignmentForm';
 
 const useStyles = makeStyles({
   table: {
@@ -18,32 +15,13 @@ const useStyles = makeStyles({
 
 export default function GradesTable(props) {
   const classes = useStyles;
-  const [assignment, setAssignment] = useState("");
-  const [dueDate, setDueDate] = useState(new Date());
-  const [completed, setCompleted] = useState(false);
-  const [grade, setGrade] = useState(null);
+  const [editRow, setEditRow] = useState(-1);
 
-  const handleAddAssignment = async () => {
-    const newAssignment = await GradesAPI.createAssignment({
-      name: assignment,
-      due_date: dueDate,
-      completed: completed,
-      grade: grade,
-      type_id: props.type._id,
-    });
-    props.setAssignments((state) => ({
-      ...state,
-      [props.type.name]: [
-        ...state[props.type.name],
-        newAssignment,
-      ],
-    }));
-
-    // Clear form
-    setAssignment("");
-    setDueDate(new Date());
-    setCompleted(false);
-    setGrade(null);
+  const handleMoreClick = (e, assignment, index) => {
+    props.setAnchorEl(e.target);
+    props.setMenuType("assignment");
+    props.setMenuTarget(assignment);
+    setEditRow(index);
   }
 
   return (
@@ -60,6 +38,15 @@ export default function GradesTable(props) {
         </TableHead>
         <TableBody>
           {props.assignments ? props.assignments.map((assignment, index) => (
+            props.assignmentEdit && editRow === index ?
+            <AssignmentForm
+              key={ index }
+              current={ assignment }
+              setAssignments={ props.setAssignments }
+              type={ props.type }
+              setAssignmentEdit={ props.setAssignmentEdit }
+            />
+            :
             <TableRow key={index}>
               <TableCell component="th" scope="row">
                 { assignment.name }
@@ -68,62 +55,17 @@ export default function GradesTable(props) {
               <TableCell align="right">{ assignment.completed ? <DoneIcon /> : null }</TableCell>
               <TableCell align="right">{ assignment.grade }</TableCell>
               <TableCell align="right">
-                <IconButton onClick={(e) => {props.setAnchorEl(e.target); props.setMenuType("assignment"); props.setMenuTarget(assignment)}}>
+                <IconButton onClick={(e) => {handleMoreClick(e, assignment, index)}}>
                   <MoreHorizIcon />
                 </IconButton>
               </TableCell>
             </TableRow>
           )) : null}
           {/* Add Assignment Row */}
-          <TableRow>
-            <TableCell component="th" scope="row">
-              <TextField
-                margin="dense"
-                label="Assignment Name"
-                fullWidth
-                size="small"
-                onChange={(e) => {setAssignment(e.target.value)}}
-              />
-            </TableCell>
-            <TableCell align="right">
-              <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                <KeyboardDatePicker
-                  disableToolbar
-                  variant="inline"
-                  format="MM/dd/yyyy"
-                  margin="normal"
-                  label="Due Date"
-                  value={dueDate}
-                  onChange={(date) => {setDueDate(date)}}
-                />
-              </MuiPickersUtilsProvider>
-            </TableCell>
-            <TableCell align="right">
-              <Checkbox
-                color="primary"
-                checked={completed}
-                onChange={(e) => {setCompleted(!completed)}}
-              />
-            </TableCell>
-            <TableCell align="right">
-              <TextField
-                margin="dense"
-                label="Grade"
-                size="small"
-                disabled={!completed}
-                onChange={(e) => {setGrade(e.target.value)}}
-              />
-            </TableCell>
-            <TableCell align="right">
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleAddAssignment}
-              >
-                Add
-              </Button>
-            </TableCell>
-          </TableRow>
+          <AssignmentForm
+            setAssignments={ props.setAssignments }
+            type={ props.type }
+          />
         </TableBody>
       </Table>
     </TableContainer>

--- a/client/src/components/grades/GradesTable.js
+++ b/client/src/components/grades/GradesTable.js
@@ -45,8 +45,6 @@ export default function GradesTable(props) {
     setGrade(null);
   }
 
-  console.log(props.assignments);
-
   return (
     <TableContainer component={Paper}>
       <Table className={classes.table}>

--- a/client/src/components/grades/GradesTable.js
+++ b/client/src/components/grades/GradesTable.js
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 
 import { makeStyles } from '@material-ui/core/styles';
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, TextField, Checkbox, Button } from '@material-ui/core';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, TextField, Checkbox, Button, IconButton } from '@material-ui/core';
 import DoneIcon from '@material-ui/icons/Done';
+import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import { MuiPickersUtilsProvider, KeyboardDatePicker } from '@material-ui/pickers';
 import DateFnsUtils from '@date-io/date-fns';
 
@@ -66,6 +67,11 @@ export default function GradesTable(props) {
               <TableCell align="right">{ new Date(assignment.due_date).toLocaleDateString() }</TableCell>
               <TableCell align="right">{ assignment.completed ? <DoneIcon /> : null }</TableCell>
               <TableCell align="right">{ assignment.grade }</TableCell>
+              <TableCell align="right">
+                <IconButton onClick={(e) => {props.setAnchorEl(e.target); props.setMenuType("assignment"); props.setMenuTarget(assignment)}}>
+                  <MoreHorizIcon />
+                </IconButton>
+              </TableCell>
             </TableRow>
           )) : null}
           {/* Add Assignment Row */}

--- a/client/src/components/grades/MoreMenu.js
+++ b/client/src/components/grades/MoreMenu.js
@@ -6,6 +6,7 @@ import DeleteIcon from '@material-ui/icons/Delete';
 import AddIcon from '@material-ui/icons/Add';
 
 import CourseForm from './CourseForm';
+import SemesterForm from './SemesterForm';
 import AddAssignmentTypeForm from './AddAssignmentTypeForm';
 import DeleteForm from './DeleteForm';
 
@@ -34,7 +35,7 @@ export default function MoreMenu(props) {
     'edit': {
       'semester': {
         content: 'Edit this semester',
-        form: null,
+        form: <SemesterForm setSemesters={ props.setSemesters } current={ props.target } />
       },
       'course': {
         content: 'Edit this course',

--- a/client/src/components/grades/MoreMenu.js
+++ b/client/src/components/grades/MoreMenu.js
@@ -8,6 +8,7 @@ import AddIcon from '@material-ui/icons/Add';
 import AddSemesterForm from './AddSemesterForm';
 import CourseForm from './CourseForm';
 import AddAssignmentTypeForm from './AddAssignmentTypeForm';
+import DeleteForm from './DeleteForm';
 
 const useStyles = makeStyles((theme) => ({
   icon: {
@@ -16,6 +17,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function MoreMenu(props) {
+  console.log(props);
   const formTypes = {
     'add': {
       'semester': {
@@ -43,7 +45,7 @@ export default function MoreMenu(props) {
     },
     'delete': {
       content: '',
-      form: null,
+      form: <DeleteForm type={ props.type } current={ props.target } />,
     },
   }
 
@@ -55,17 +57,21 @@ export default function MoreMenu(props) {
   }
 
   const handleAdd = () => {
+    props.setActionType('add');
     props.setDialogForm(formTypes['add'][props.type]);
     props.setMenuOpen(true);
   }
 
   const handleEdit = () => {
+    props.setActionType('edit');
     props.setDialogForm(formTypes['edit'][props.type]);
     props.setMenuOpen(true);
   }
 
   const handleDelete = () => {
-
+    props.setActionType('delete');
+    props.setDialogForm(formTypes['delete']);
+    props.setMenuOpen(true);
   }
 
   return (

--- a/client/src/components/grades/MoreMenu.js
+++ b/client/src/components/grades/MoreMenu.js
@@ -7,7 +7,7 @@ import AddIcon from '@material-ui/icons/Add';
 
 import CourseForm from './CourseForm';
 import SemesterForm from './SemesterForm';
-import AddAssignmentTypeForm from './AddAssignmentTypeForm';
+import AssignmentTypeForm from './AssignmentTypeForm';
 import DeleteForm from './DeleteForm';
 
 const useStyles = makeStyles((theme) => ({
@@ -25,11 +25,7 @@ export default function MoreMenu(props) {
       },
       'course': {
         content: 'Add a new assignment type. Give a name, the weight, and the number of allowed drops',
-        form: <AddAssignmentTypeForm setAssignmentTypes={ props.setAssignmentTypes } course={ props.target } />
-      },
-      'assignment type': {
-        content: 'Add a new assignment type. Give a name, the weight, and the number of allowed drops',
-        form: <AddAssignmentTypeForm setAssignmentTypes={ props.setAssignmentTypes } course={ props.course } />
+        form: <AssignmentTypeForm setAssignmentTypes={ props.setAssignmentTypes } course={ props.target } />
       },
     },
     'edit': {
@@ -40,6 +36,10 @@ export default function MoreMenu(props) {
       'course': {
         content: 'Edit this course',
         form: <CourseForm setCourses={ props.setCourses } semesters={ props.semesters } current={ props.target } />
+      },
+      'assignment type': {
+        content: 'Edit this assignment type',
+        form: <AssignmentTypeForm setAssignmentTypes={ props.setAssignmentTypes } current={ props.target } />
       }
     },
     'delete': {
@@ -80,10 +80,10 @@ export default function MoreMenu(props) {
       open={Boolean(props.anchorEl)}
       onClose={handleMenuClose}
     >
-      <MenuItem onClick={handleAdd}>
+      {(props.type !== 'assignment type') && <MenuItem onClick={handleAdd}>
         <AddIcon className={classes.icon} />
         Add
-      </MenuItem>
+      </MenuItem>}
       <MenuItem onClick={handleEdit}>
         <EditIcon className={classes.icon} />
         Edit

--- a/client/src/components/grades/MoreMenu.js
+++ b/client/src/components/grades/MoreMenu.js
@@ -5,17 +5,67 @@ import EditIcon from '@material-ui/icons/Edit';
 import DeleteIcon from '@material-ui/icons/Delete';
 import AddIcon from '@material-ui/icons/Add';
 
+import AddSemesterForm from './AddSemesterForm';
+import CourseForm from './CourseForm';
+import AddAssignmentTypeForm from './AddAssignmentTypeForm';
+
 const useStyles = makeStyles((theme) => ({
   icon: {
     paddingRight: theme.spacing(2),
   },
 }));
 
-export default function EditMenu(props) {
+export default function MoreMenu(props) {
+  const formTypes = {
+    'add': {
+      'semester': {
+        content: 'Add a new semester. Give a name (e.g. Fall 2019) and denote if this is your current semester',
+        form: <AddSemesterForm setSemesters={ props.setSemesters } />
+      },
+      'course': {
+        content: 'Add a new course. Give a name, provide the grade cutoffs, and select the associated semester',
+        form: <CourseForm setCourses={ props.setCourses } semesters={ props.semesters } />
+      },
+      'assignment type': {
+        content: 'Add a new assignment type. Give a name, the weight, and the number of allowed drops',
+        form: <AddAssignmentTypeForm setAssignmentTypes={ props.setAssignmentTypes } course={ props.course } />
+      },
+    },
+    'edit': {
+      'semester': {
+        content: 'Edit this semester',
+        form: null,
+      },
+      'course': {
+        content: 'Edit this course',
+        form: <CourseForm setCourses={ props.setCourses } semesters={ props.semesters } current={ props.target } />
+      }
+    },
+    'delete': {
+      content: '',
+      form: null,
+    },
+  }
+
   const classes = useStyles();
 
   const handleMenuClose = () => {
     props.setAnchorEl(null);
+    props.setTarget(null);
+  }
+
+  const handleAdd = () => {
+    props.setDialogForm(formTypes['add'][props.type]);
+    props.setMenuOpen(true);
+  }
+
+  const handleEdit = () => {
+    props.setDialogForm(formTypes['edit'][props.type]);
+    props.setMenuOpen(true);
+  }
+
+  const handleDelete = () => {
+
   }
 
   return (
@@ -25,15 +75,15 @@ export default function EditMenu(props) {
       open={Boolean(props.anchorEl)}
       onClose={handleMenuClose}
     >
-      <MenuItem>
+      <MenuItem onClick={handleAdd}>
         <AddIcon className={classes.icon} />
         Add
       </MenuItem>
-      <MenuItem>
+      <MenuItem onClick={handleEdit}>
         <EditIcon className={classes.icon} />
         Edit
       </MenuItem>
-      <MenuItem>
+      <MenuItem onClick={handleDelete}>
         <DeleteIcon className={classes.icon} />
         Delete
       </MenuItem>

--- a/client/src/components/grades/MoreMenu.js
+++ b/client/src/components/grades/MoreMenu.js
@@ -5,7 +5,6 @@ import EditIcon from '@material-ui/icons/Edit';
 import DeleteIcon from '@material-ui/icons/Delete';
 import AddIcon from '@material-ui/icons/Add';
 
-import AddSemesterForm from './AddSemesterForm';
 import CourseForm from './CourseForm';
 import AddAssignmentTypeForm from './AddAssignmentTypeForm';
 import DeleteForm from './DeleteForm';
@@ -20,12 +19,12 @@ export default function MoreMenu(props) {
   const formTypes = {
     'add': {
       'semester': {
-        content: 'Add a new semester. Give a name (e.g. Fall 2019) and denote if this is your current semester',
-        form: <AddSemesterForm setSemesters={ props.setSemesters } />
-      },
-      'course': {
         content: 'Add a new course. Give a name, provide the grade cutoffs, and select the associated semester',
         form: <CourseForm setCourses={ props.setCourses } semesters={ props.semesters } />
+      },
+      'course': {
+        content: 'Add a new assignment type. Give a name, the weight, and the number of allowed drops',
+        form: <AddAssignmentTypeForm setAssignmentTypes={ props.setAssignmentTypes } course={ props.target } />
       },
       'assignment type': {
         content: 'Add a new assignment type. Give a name, the weight, and the number of allowed drops',
@@ -44,7 +43,7 @@ export default function MoreMenu(props) {
     },
     'delete': {
       content: '',
-      form: <DeleteForm type={ props.type } current={ props.target } semesters={ props.semesters } setCourses={ props.setCourses } />,
+      form: <DeleteForm type={ props.type } current={ props.target } semesters={ props.semesters } setSemesters={ props.setSemesters } setCourses={ props.setCourses } />,
     },
   }
 

--- a/client/src/components/grades/MoreMenu.js
+++ b/client/src/components/grades/MoreMenu.js
@@ -66,7 +66,9 @@ export default function MoreMenu(props) {
               semesters={ props.semesters }
               setSemesters={ props.setSemesters }
               setCourses={ props.setCourses }
+              assignmentTypes={ props.assignmentTypes }
               setAssignmentTypes={ props.setAssignmentTypes }
+              setAssignments={ props.setAssignments }
             />,
     },
   }
@@ -103,7 +105,7 @@ export default function MoreMenu(props) {
       open={Boolean(props.anchorEl)}
       onClose={handleMenuClose}
     >
-      {(props.type !== 'assignment type') && <MenuItem onClick={handleAdd}>
+      {(props.type !== 'assignment type' && props.type !== 'assignment') && <MenuItem onClick={handleAdd}>
         <AddIcon className={classes.icon} />
         Add
       </MenuItem>}

--- a/client/src/components/grades/MoreMenu.js
+++ b/client/src/components/grades/MoreMenu.js
@@ -21,30 +21,53 @@ export default function MoreMenu(props) {
     'add': {
       'semester': {
         content: 'Add a new course. Give a name, provide the grade cutoffs, and select the associated semester',
-        form: <CourseForm setCourses={ props.setCourses } semesters={ props.semesters } />
+        form: <CourseForm
+                setCourses={ props.setCourses }
+                semesters={ props.semesters } 
+              />
       },
       'course': {
         content: 'Add a new assignment type. Give a name, the weight, and the number of allowed drops',
-        form: <AssignmentTypeForm setAssignmentTypes={ props.setAssignmentTypes } course={ props.target } />
+        form: <AssignmentTypeForm
+                setAssignmentTypes={ props.setAssignmentTypes }
+                course={ props.target }
+              />
       },
     },
     'edit': {
       'semester': {
         content: 'Edit this semester',
-        form: <SemesterForm setSemesters={ props.setSemesters } current={ props.target } />
+        form: <SemesterForm
+                setSemesters={ props.setSemesters }
+                current={ props.target }
+              />
       },
       'course': {
         content: 'Edit this course',
-        form: <CourseForm setCourses={ props.setCourses } semesters={ props.semesters } current={ props.target } />
+        form: <CourseForm
+                setCourses={ props.setCourses }
+                semesters={ props.semesters }
+                current={ props.target }
+              />
       },
       'assignment type': {
         content: 'Edit this assignment type',
-        form: <AssignmentTypeForm setAssignmentTypes={ props.setAssignmentTypes } current={ props.target } />
+        form: <AssignmentTypeForm
+                setAssignmentTypes={ props.setAssignmentTypes }
+                current={ props.target }
+              />
       }
     },
     'delete': {
       content: '',
-      form: <DeleteForm type={ props.type } current={ props.target } semesters={ props.semesters } setSemesters={ props.setSemesters } setCourses={ props.setCourses } />,
+      form: <DeleteForm 
+              type={ props.type }
+              current={ props.target }
+              semesters={ props.semesters }
+              setSemesters={ props.setSemesters }
+              setCourses={ props.setCourses }
+              setAssignmentTypes={ props.setAssignmentTypes }
+            />,
     },
   }
 

--- a/client/src/components/grades/MoreMenu.js
+++ b/client/src/components/grades/MoreMenu.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Menu, MenuItem } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import EditIcon from '@material-ui/icons/Edit';
+import DeleteIcon from '@material-ui/icons/Delete';
+import AddIcon from '@material-ui/icons/Add';
+
+const useStyles = makeStyles((theme) => ({
+  icon: {
+    paddingRight: theme.spacing(2),
+  },
+}));
+
+export default function EditMenu(props) {
+  const classes = useStyles();
+
+  const handleMenuClose = () => {
+    props.setAnchorEl(null);
+  }
+
+  return (
+    <Menu
+      anchorEl={props.anchorEl}
+      keepMounted
+      open={Boolean(props.anchorEl)}
+      onClose={handleMenuClose}
+    >
+      <MenuItem>
+        <AddIcon className={classes.icon} />
+        Add
+      </MenuItem>
+      <MenuItem>
+        <EditIcon className={classes.icon} />
+        Edit
+      </MenuItem>
+      <MenuItem>
+        <DeleteIcon className={classes.icon} />
+        Delete
+      </MenuItem>
+    </Menu>
+  );
+}

--- a/client/src/components/grades/MoreMenu.js
+++ b/client/src/components/grades/MoreMenu.js
@@ -17,7 +17,6 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function MoreMenu(props) {
-  console.log(props);
   const formTypes = {
     'add': {
       'semester': {
@@ -45,7 +44,7 @@ export default function MoreMenu(props) {
     },
     'delete': {
       content: '',
-      form: <DeleteForm type={ props.type } current={ props.target } />,
+      form: <DeleteForm type={ props.type } current={ props.target } semesters={ props.semesters } setCourses={ props.setCourses } />,
     },
   }
 

--- a/client/src/components/grades/MoreMenu.js
+++ b/client/src/components/grades/MoreMenu.js
@@ -87,9 +87,14 @@ export default function MoreMenu(props) {
   }
 
   const handleEdit = () => {
-    props.setActionType('edit');
-    props.setDialogForm(formTypes['edit'][props.type]);
-    props.setMenuOpen(true);
+    if (props.type === 'assignment') {
+      props.setAssignmentEdit(true);
+      handleMenuClose();
+    } else {
+      props.setActionType('edit');
+      props.setDialogForm(formTypes['edit'][props.type]);
+      props.setMenuOpen(true);
+    }
   }
 
   const handleDelete = () => {

--- a/client/src/components/grades/SemesterForm.js
+++ b/client/src/components/grades/SemesterForm.js
@@ -4,24 +4,38 @@ import { TextField, FormControlLabel, Switch } from '@material-ui/core';
 
 import GradesAPI from '../../pages/GradesAPI';
 
-export default function AddSemesterForm(props) {
-  const [semesterName, setSemesterName] = useState("");
-  const [checkedCurrent, setCheckedCurrent] = useState(false);
+export default function SemesterForm(props) {
+  const [semesterName, setSemesterName] = useState(props.current ? props.current.name : "");
+  const [checkedCurrent, setCheckedCurrent] = useState(props.current ? props.current.current : false);
 
   const addSemester = async () => {
     const newSemester = await GradesAPI.createSemester({
       name: semesterName,
       current: checkedCurrent,
     });
-    props.setSemesters((state, props) => ([
+    props.setSemesters((state) => ([
       ...state,
       newSemester,
     ]));
   }
 
+  const updateSemester = async () => {
+    const updatedSemester = await GradesAPI.updateSemester(props.current._id, {
+      name: semesterName,
+      current: checkedCurrent,
+    });
+    props.setSemesters((state) => (state.map(semester => (
+      semester._id === props.current._id ? updatedSemester : semester
+    ))));
+  }
+
   useEffect(() => {
     if (props.submitted) {
-      addSemester();
+      if (props.current) {
+        updateSemester();
+      } else {
+        addSemester();
+      }
       props.setSubmitted(false);
     }
   }, [props.submitted]);
@@ -30,6 +44,7 @@ export default function AddSemesterForm(props) {
     <div>
       <TextField
         autoFocus
+        value={semesterName}
         margin="dense"
         label="Semester Name"
         fullWidth

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -40,6 +40,9 @@ const useStyles = makeStyles((theme) => ({
   addSemester: {
     paddingRight: theme.spacing(2),
   },
+  grow: {
+    flexGrow: 1,
+  },
   // necessary for content to be below app bar
   toolbar: theme.mixins.toolbar,
   content: {
@@ -216,7 +219,13 @@ export default function Grades(props) {
         {/* Assignment Tables */}
         {assignmentTypes.map((type, index) => (
           <div key={index}>
-            <Typography variant="h5" align="left">{ type.name }</Typography>
+            <Toolbar>
+              <Typography variant="h5" edge="start">{ type.name }</Typography>
+              <div className={classes.grow} />
+              <IconButton edge="end">
+                <MoreHorizIcon onClick={(e) => {setAnchorEl(e.target); setMenuType("assignment type"); setMenuTarget(type)}}/>
+              </IconButton>
+            </Toolbar>
             <GradesTable assignments={ assignments[type.name] } type={ type } setAssignments={ setAssignments } />
             <Toolbar />
           </div>

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -8,9 +8,11 @@ import { Drawer, List, ListSubheader,
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
+import AddIcon from '@material-ui/icons/Add';
 
 import DialogForm from '../components/DialogForm';
 import GradesTable from '../components/grades/GradesTable';
+import AddSemesterForm from '../components/grades/AddSemesterForm';
 import MoreMenu from '../components/grades/MoreMenu';
 
 const drawerWidth = 240;
@@ -34,6 +36,9 @@ const useStyles = makeStyles((theme) => ({
     paddingLeft: theme.spacing(4),
   },
   listItemSecondary: {
+  },
+  addSemester: {
+    paddingRight: theme.spacing(2),
   },
   // necessary for content to be below app bar
   toolbar: theme.mixins.toolbar,
@@ -64,6 +69,11 @@ export default function Grades(props) {
   const [menuTarget, setMenuTarget] = useState(null);
   const [actionType, setActionType] = useState("");
   const [dialogForm, setDialogForm] = useState(null);
+
+  const addSemesterForm = {
+    content: 'Add a new semester. Give a name (e.g. Fall 2019) and denote if this is your current semester',
+    form: <AddSemesterForm setSemesters={ setSemesters } />
+  }
 
   useEffect(() => {
     const fetchAndSetSemesters = async () => {
@@ -103,6 +113,12 @@ export default function Grades(props) {
     } else {
       setSemester(name);
     }
+  }
+
+  const handleAddSemester = () => {
+    setActionType('add');
+    setDialogForm(addSemesterForm);
+    setMenuOpen(true);
   }
 
   const handleCourseSelect = async (course) => {
@@ -170,6 +186,13 @@ export default function Grades(props) {
               </Collapse>
             </div>
           ))}
+          <ListItem
+            button
+            onClick={handleAddSemester}
+          >
+            <AddIcon className={classes.addSemester} />
+            <ListItemText primary="Add New Semester" />
+          </ListItem>
         </List>
         {/* Edit Menu */}
         <MoreMenu

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -62,6 +62,7 @@ export default function Grades(props) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuType, setMenuType] = useState("");
   const [menuTarget, setMenuTarget] = useState(null);
+  const [actionType, setActionType] = useState("");
   const [dialogForm, setDialogForm] = useState(null);
 
   useEffect(() => {
@@ -172,8 +173,8 @@ export default function Grades(props) {
         </List>
         {/* Edit Menu */}
         <MoreMenu
-          type={menuType}
           target={menuTarget}
+          type={menuType}
           setTarget={setMenuTarget}
           anchorEl={anchorEl}
           setAnchorEl={setAnchorEl}
@@ -182,6 +183,7 @@ export default function Grades(props) {
           setSemesters={setSemesters}
           setCourses={setCourses}
           setAssignmentTypes={setAssignmentTypes}
+          setActionType={setActionType}
           semesters={semesters}
           course={course}
         />
@@ -198,7 +200,8 @@ export default function Grades(props) {
         ))}
         {/* Form Dialog */}
         <DialogForm
-          title="Add New Item"
+          type={ menuType }
+          actionType={ actionType }
           content={ dialogForm ? dialogForm.content : '' }
           form={ dialogForm ? dialogForm.form : null }
           open={ menuOpen }

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -2,17 +2,19 @@ import React, { useState, useEffect } from 'react';
 import GradesAPI from './GradesAPI';
 
 import { makeStyles } from '@material-ui/core/styles';
-import { Menu, MenuItem, Fab, Drawer, List, ListSubheader, 
-          ListItem, ListItemText, Toolbar, Collapse, Typography } from '@material-ui/core';
-import AddIcon from '@material-ui/icons/Add';
+import { Drawer, List, ListSubheader, 
+          ListItem, ListItemText, ListItemSecondaryAction, Toolbar, 
+          Collapse, Typography, IconButton } from '@material-ui/core';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
+import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 
 import DialogForm from '../components/DialogForm';
 import AddSemesterForm from '../components/grades/AddSemesterForm';
 import AddCourseForm from '../components/grades/AddCourseForm';
 import AddAssignmentTypeForm from '../components/grades/AddAssignmentTypeForm';
 import GradesTable from '../components/grades/GradesTable';
+import MoreMenu from '../components/grades/MoreMenu';
 
 const drawerWidth = 240;
 
@@ -33,6 +35,8 @@ const useStyles = makeStyles((theme) => ({
   },
   drawerSubList: {
     paddingLeft: theme.spacing(4),
+  },
+  listItemSecondary: {
   },
   // necessary for content to be below app bar
   toolbar: theme.mixins.toolbar,
@@ -58,8 +62,8 @@ export default function Grades(props) {
 
   // UI States
   const [anchorEl, setAnchorEl] = useState(null);
-  const [addOpen, setAddOpen] = useState(false);
-  const [addForm, setAddForm] = useState(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [dialogForm, setDialogForm] = useState(null);
 
   const formTypes = {
     'semester': {
@@ -116,10 +120,6 @@ export default function Grades(props) {
     }
   }
 
-  const handleMenuClose = () => {
-    setAnchorEl(null);
-  }
-
   const handleCourseSelect = async (course) => {
     setCourse(course);
     const newAssignmentTypes = await GradesAPI.getAllAssignmentTypes(course);
@@ -151,10 +151,16 @@ export default function Grades(props) {
             <div key={index}>
               <ListItem
                 button
-                onClick={() => {handleSemesterClick(name)}}
               >
                 <ListItemText primary={name} />
-                { semester === name ? <ExpandLess /> : <ExpandMore /> }
+                <ListItemSecondaryAction className={classes.listItemSecondary}>
+                  <IconButton onClick={(e) => {setAnchorEl(e.target)}}>
+                    <MoreHorizIcon />
+                  </IconButton>
+                  <IconButton onClick={() => {handleSemesterClick(name)}}>
+                    { semester === name ? <ExpandLess /> : <ExpandMore /> }
+                  </IconButton>
+                </ListItemSecondaryAction>
               </ListItem>
               {/* List of courses for this semester */}
               <Collapse in={semester === name} timeout="auto" unmountOnExit>
@@ -168,6 +174,11 @@ export default function Grades(props) {
                       onClick={() => {handleCourseSelect(c)}}
                     >
                       <ListItemText primary={c.name} />
+                      <ListItemSecondaryAction>
+                        <IconButton edge="end" onClick={(e) => {setAnchorEl(e.target)}}>
+                          <MoreHorizIcon />
+                        </IconButton>
+                      </ListItemSecondaryAction>
                     </ListItem>
                   ))}
                 </List>
@@ -175,6 +186,12 @@ export default function Grades(props) {
             </div>
           ))}
         </List>
+        {/* Edit Menu */}
+        <MoreMenu 
+          anchorEl={anchorEl}
+          setAnchorEl={setAnchorEl}
+          setMenuOpen={setMenuOpen}
+        />
       </Drawer>
       {/* Assignment Categories */}
       <main className={classes.content}>
@@ -189,30 +206,12 @@ export default function Grades(props) {
         {/* Form Dialog */}
         <DialogForm
           title="Add New Item"
-          content={ addForm ? addForm.content : '' }
-          form={ addForm ? addForm.form : null }
-          open={ addOpen }
-          setOpen={ setAddOpen }
+          content={ dialogForm ? dialogForm.content : '' }
+          form={ dialogForm ? dialogForm.form : null }
+          open={ menuOpen }
+          setOpen={ setMenuOpen }
           setAnchorEl={ setAnchorEl }
         />
-        {/* Add button */}
-        <Fab
-          className={classes.fab}
-          color="primary"
-          onClick={(e) => {setAnchorEl(e.currentTarget)}}
-        >
-          <AddIcon />
-        </Fab>
-        <Menu
-          anchorEl={anchorEl}
-          keepMounted
-          open={Boolean(anchorEl)}
-          onClose={handleMenuClose}
-        >
-          {!!course ? <MenuItem onClick={() => {setAddOpen(true); setAddForm(formTypes['assignment type'])}}>Assignment Type</MenuItem> : null}
-          <MenuItem onClick={() => {setAddOpen(true); setAddForm(formTypes['course'])}}>Course</MenuItem>
-          <MenuItem onClick={() => {setAddOpen(true); setAddForm(formTypes['semester'])}}>Semester</MenuItem>
-        </Menu>
       </main>
     </div>
   );

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -10,9 +10,6 @@ import ExpandMore from '@material-ui/icons/ExpandMore';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 
 import DialogForm from '../components/DialogForm';
-import AddSemesterForm from '../components/grades/AddSemesterForm';
-import AddCourseForm from '../components/grades/AddCourseForm';
-import AddAssignmentTypeForm from '../components/grades/AddAssignmentTypeForm';
 import GradesTable from '../components/grades/GradesTable';
 import MoreMenu from '../components/grades/MoreMenu';
 
@@ -63,22 +60,9 @@ export default function Grades(props) {
   // UI States
   const [anchorEl, setAnchorEl] = useState(null);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [menuType, setMenuType] = useState("");
+  const [menuTarget, setMenuTarget] = useState(null);
   const [dialogForm, setDialogForm] = useState(null);
-
-  const formTypes = {
-    'semester': {
-      content: 'Add a new semester. Give a name (e.g. Fall 2019) and denote if this is your current semester',
-      form: <AddSemesterForm setSemesters={ setSemesters } />
-    },
-    'course': {
-      content: 'Add a new course. Give a name, provide the grade cutoffs, and select the associated semester',
-      form: <AddCourseForm setCourses={ setCourses } semesters={ semesters } />
-    },
-    'assignment type': {
-      content: 'Add a new assignment type. Give a name, the weight, and the number of allowed drops',
-      form: <AddAssignmentTypeForm setAssignmentTypes={ setAssignmentTypes } course={ course } />
-    },
-  }
 
   useEffect(() => {
     const fetchAndSetSemesters = async () => {
@@ -147,25 +131,25 @@ export default function Grades(props) {
             </ListSubheader>
           }
         >
-          {semesters.map(({ name }, index) => (
+          {semesters.map((s, index) => (
             <div key={index}>
               <ListItem
                 button
               >
-                <ListItemText primary={name} />
+                <ListItemText primary={s.name} />
                 <ListItemSecondaryAction className={classes.listItemSecondary}>
-                  <IconButton onClick={(e) => {setAnchorEl(e.target)}}>
+                  <IconButton onClick={(e) => {setAnchorEl(e.target); setMenuType("semester"); setMenuTarget(s)}}>
                     <MoreHorizIcon />
                   </IconButton>
-                  <IconButton onClick={() => {handleSemesterClick(name)}}>
-                    { semester === name ? <ExpandLess /> : <ExpandMore /> }
+                  <IconButton onClick={() => {handleSemesterClick(s.name)}}>
+                    { semester === s.name ? <ExpandLess /> : <ExpandMore /> }
                   </IconButton>
                 </ListItemSecondaryAction>
               </ListItem>
               {/* List of courses for this semester */}
-              <Collapse in={semester === name} timeout="auto" unmountOnExit>
+              <Collapse in={semester === s.name} timeout="auto" unmountOnExit>
                 <List disablePadding>
-                  {courses[name] && courses[name].map((c, index) => (
+                  {courses[s.name] && courses[s.name].map((c, index) => (
                     <ListItem
                       key={index}
                       button
@@ -175,7 +159,7 @@ export default function Grades(props) {
                     >
                       <ListItemText primary={c.name} />
                       <ListItemSecondaryAction>
-                        <IconButton edge="end" onClick={(e) => {setAnchorEl(e.target)}}>
+                        <IconButton edge="end" onClick={(e) => {setAnchorEl(e.target); setMenuType("course"); setMenuTarget(c)}}>
                           <MoreHorizIcon />
                         </IconButton>
                       </ListItemSecondaryAction>
@@ -187,10 +171,19 @@ export default function Grades(props) {
           ))}
         </List>
         {/* Edit Menu */}
-        <MoreMenu 
+        <MoreMenu
+          type={menuType}
+          target={menuTarget}
+          setTarget={setMenuTarget}
           anchorEl={anchorEl}
           setAnchorEl={setAnchorEl}
           setMenuOpen={setMenuOpen}
+          setDialogForm={setDialogForm}
+          setSemesters={setSemesters}
+          setCourses={setCourses}
+          setAssignmentTypes={setAssignmentTypes}
+          semesters={semesters}
+          course={course}
         />
       </Drawer>
       {/* Assignment Categories */}

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -72,6 +72,7 @@ export default function Grades(props) {
   const [menuTarget, setMenuTarget] = useState(null);
   const [actionType, setActionType] = useState("");
   const [dialogForm, setDialogForm] = useState(null);
+  const [assignmentEdit, setAssignmentEdit] = useState(false);
 
   const addSemesterForm = {
     content: 'Add a new semester. Give a name (e.g. Fall 2019) and denote if this is your current semester',
@@ -213,6 +214,7 @@ export default function Grades(props) {
           setAssignmentTypes={setAssignmentTypes}
           setAssignments={setAssignments}
           setActionType={setActionType}
+          setAssignmentEdit={setAssignmentEdit}
           course={course}
         />
       </Drawer>
@@ -235,6 +237,8 @@ export default function Grades(props) {
               setAnchorEl={ setAnchorEl }
               setMenuType={ setMenuType }
               setMenuTarget={ setMenuTarget }
+              assignmentEdit={ assignmentEdit }
+              setAssignmentEdit={ setAssignmentEdit }
             />
             <Toolbar />
           </div>

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -222,8 +222,8 @@ export default function Grades(props) {
             <Toolbar>
               <Typography variant="h5" edge="start">{ type.name }</Typography>
               <div className={classes.grow} />
-              <IconButton edge="end">
-                <MoreHorizIcon onClick={(e) => {setAnchorEl(e.target); setMenuType("assignment type"); setMenuTarget(type)}}/>
+              <IconButton edge="end" onClick={(e) => {setAnchorEl(e.target); setMenuType("assignment type"); setMenuTarget(type)}}>
+                <MoreHorizIcon />
               </IconButton>
             </Toolbar>
             <GradesTable assignments={ assignments[type.name] } type={ type } setAssignments={ setAssignments } />

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -206,11 +206,13 @@ export default function Grades(props) {
           setAnchorEl={setAnchorEl}
           setMenuOpen={setMenuOpen}
           setDialogForm={setDialogForm}
+          semesters={semesters}
           setSemesters={setSemesters}
           setCourses={setCourses}
+          assignmentTypes={assignmentTypes}
           setAssignmentTypes={setAssignmentTypes}
+          setAssignments={setAssignments}
           setActionType={setActionType}
-          semesters={semesters}
           course={course}
         />
       </Drawer>
@@ -226,7 +228,14 @@ export default function Grades(props) {
                 <MoreHorizIcon />
               </IconButton>
             </Toolbar>
-            <GradesTable assignments={ assignments[type.name] } type={ type } setAssignments={ setAssignments } />
+            <GradesTable
+              type={ type }
+              assignments={ assignments[type.name] }
+              setAssignments={ setAssignments }
+              setAnchorEl={ setAnchorEl }
+              setMenuType={ setMenuType }
+              setMenuTarget={ setMenuTarget }
+            />
             <Toolbar />
           </div>
         ))}

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -12,7 +12,7 @@ import AddIcon from '@material-ui/icons/Add';
 
 import DialogForm from '../components/DialogForm';
 import GradesTable from '../components/grades/GradesTable';
-import AddSemesterForm from '../components/grades/AddSemesterForm';
+import AddSemesterForm from '../components/grades/SemesterForm';
 import MoreMenu from '../components/grades/MoreMenu';
 
 const drawerWidth = 240;

--- a/server/models/grades/assignmentType.js
+++ b/server/models/grades/assignmentType.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
+const Assignment = require('./assignment');
 
 const assignmentTypeSchema = new Schema({
   name: {
@@ -17,6 +18,22 @@ const assignmentTypeSchema = new Schema({
   course_id: {
     type: Schema.Types.ObjectId,
     required: true,
+  }
+});
+
+assignmentTypeSchema.pre('deleteOne', async function() {
+  const id = this._conditions._id;
+  Assignment.deleteMany({type_id: id}, (err) => {
+    if (err)
+      console.log(err);
+  });
+});
+
+assignmentTypeSchema.pre('deleteMany', async function() {
+  const course = this._conditions.course_id;
+  const assignmentTypes = await this.model.find({ course_id: course });
+  for (const type of assignmentTypes) {
+    await Assignment.deleteMany({ type_id: type._id });
   }
 });
 

--- a/server/models/grades/course.js
+++ b/server/models/grades/course.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
+const AssignmentType = require('./assignmentType');
 
 
 const defaultCutoffs = {
@@ -28,6 +29,22 @@ const courseSchema = new Schema({
   semester_id: {
     type: Schema.Types.ObjectId,
     required: true,
+  }
+});
+
+courseSchema.pre('deleteOne', async function() {
+  const id = this._conditions._id;
+  AssignmentType.deleteMany({course_id: id}, (err) => {
+    if (err)
+      console.log(err);
+  });
+})
+
+courseSchema.pre('deleteMany', async function() {
+  const semester = this._conditions.semester_id;
+  const courses = await this.model.find({ semester_id: semester });
+  for (const course of courses) {
+    await AssignmentType.deleteMany({ course_id: course._id });
   }
 });
 

--- a/server/models/grades/semester.js
+++ b/server/models/grades/semester.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
+const Course = require('./course');
 
 const semesterSchema = new Schema({
   name: {
@@ -13,6 +14,22 @@ const semesterSchema = new Schema({
   user_id: {
     type: Schema.Types.ObjectId,
     required: true,
+  }
+});
+
+semesterSchema.pre('deleteOne', async function() {
+  const id = this._conditions._id;
+  Course.deleteMany({semester_id: id}, (err) => {
+    if (err)
+      console.log(err);
+  });
+});
+
+semesterSchema.pre('deleteMany', async function() {
+  const user = this._conditions.user_id;
+  const semesters = await this.model.find({ user_id: user });
+  for (const semester of semesters) {
+    await Course.deleteMany({ semester_id: semester._id });
   }
 });
 

--- a/server/routes/grades/semesters.js
+++ b/server/routes/grades/semesters.js
@@ -54,7 +54,7 @@ router.put('/:id', async (req, res, next) => {
  */
 router.delete('/:id', async (req, res, next) => {
   try {
-    await Semester.findByIdAndDelete(req.params.id);
+    await Semester.deleteOne({ _id: req.params.id });
     return res.status(200).json('Deleted semester');
   } catch (err) {
     next({ status: 400, message: 'Failed to delete semester' });


### PR DESCRIPTION
### Problem
While using the grades widget, there was no way to edit or delete any of the items. This only allowed for very limited functionality.

### Solution
I removed the Floating Action Button in favor of dispersed "More" action buttons (the three dots icon). This way, whenever you click on a button, it's clear what item it's affecting. You can now add, edit, and delete all of the semesters, courses, assignment types, and assignments. Additionally, I also added a pseudo cascade delete system on the server side. This way, if a user deletes a semester from the database, it deletes all associated courses, assignment types of those courses, and assignments of those assignment types. 

### Testing
I tested this by creating new items of all types and then editing and deleting them. I then refreshed the page to show that the database was updated properly. The items were also updated in real time on the frontend without page refresh. 

Closes #44 