### PR TITLE
Grades - Upcoming Assignments

### DIFF
--- a/client/src/components/grades/AssignmentForm.js
+++ b/client/src/components/grades/AssignmentForm.js
@@ -19,6 +19,8 @@ export default function AssignmentForm(props) {
       completed: completed,
       grade: grade,
       type_id: props.type._id,
+      course_id: props.course._id,
+      semester_id: props.course.semester_id,
     });
     props.setAssignments((state) => ({
       ...state,
@@ -42,6 +44,8 @@ export default function AssignmentForm(props) {
       completed: completed,
       grade: grade,
       type_id: props.type._id,
+      course_id: props.course._id,
+      semester_id: props.course.semester_id,
     });
     props.setAssignments((state) => ({
       ...state,

--- a/client/src/components/grades/GradesTable.js
+++ b/client/src/components/grades/GradesTable.js
@@ -30,10 +30,11 @@ export default function GradesTable(props) {
         <TableHead>
           <TableRow>
             <TableCell>Assignment</TableCell>
-            <TableCell align="right">Due Date</TableCell>
-            <TableCell align="right">Completed</TableCell>
-            <TableCell align="right">Grade</TableCell>
-            <TableCell align="right"></TableCell>
+            { props.upcoming && <TableCell align="right">Course</TableCell> }
+            { !props.upcoming && <TableCell align="right">Due Date</TableCell> }
+            { !props.upcoming && <TableCell align="right">Completed</TableCell> }
+            { !props.upcoming && <TableCell align="right">Grade</TableCell> }
+            { !props.upcoming && <TableCell align="right"></TableCell> }
           </TableRow>
         </TableHead>
         <TableBody>
@@ -43,6 +44,7 @@ export default function GradesTable(props) {
               key={ index }
               current={ assignment }
               setAssignments={ props.setAssignments }
+              course={ props.course }
               type={ props.type }
               setAssignmentEdit={ props.setAssignmentEdit }
             />
@@ -51,21 +53,23 @@ export default function GradesTable(props) {
               <TableCell component="th" scope="row">
                 { assignment.name }
               </TableCell>
-              <TableCell align="right">{ new Date(assignment.due_date).toLocaleDateString() }</TableCell>
-              <TableCell align="right">{ assignment.completed ? <DoneIcon /> : null }</TableCell>
-              <TableCell align="right">{ assignment.grade }</TableCell>
-              <TableCell align="right">
+              { props.upcoming && <TableCell align="right">{ props.courses.find(c => (c._id === assignment.course_id)) ? props.courses.find(c => (c._id === assignment.course_id)).name : null }</TableCell> }
+              { !props.upcoming && <TableCell align="right">{ new Date(assignment.due_date).toLocaleDateString() }</TableCell> }
+              { !props.upcoming && <TableCell align="right">{ assignment.completed ? <DoneIcon /> : null }</TableCell> }
+              { !props.upcoming && <TableCell align="right">{ assignment.grade }</TableCell> }
+              { !props.upcoming && <TableCell align="right">
                 <IconButton onClick={(e) => {handleMoreClick(e, assignment, index)}}>
                   <MoreHorizIcon />
                 </IconButton>
-              </TableCell>
+              </TableCell> }
             </TableRow>
           )) : null}
           {/* Add Assignment Row */}
-          <AssignmentForm
+          { !props.upcoming && <AssignmentForm
             setAssignments={ props.setAssignments }
             type={ props.type }
-          />
+            course={ props.course }
+          /> }
         </TableBody>
       </Table>
     </TableContainer>

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -65,6 +65,8 @@ export default function Grades(props) {
   const [course, setCourse] = useState(null);
   const [assignmentTypes, setAssignmentTypes] = useState([]);
   const [assignments, setAssignments] = useState({});
+  const [assignmentDates, setAssignmentDates] = useState([]);
+  const [upcomingAssignments, setUpcomingAssignments] = useState({});
 
   // UI States
   const [anchorEl, setAnchorEl] = useState(null);
@@ -115,6 +117,10 @@ export default function Grades(props) {
   const handleSemesterClick = async (s) => {
     setSemester(s);
     setCourse(null);
+    const upcoming = await GradesAPI.getAllUpcomingAssignments(s);
+    console.log(upcoming);
+    setUpcomingAssignments(upcoming);
+    setAssignmentDates(Object.keys(upcoming));
   }
 
   const handleSemesterDropdown = (name) => {
@@ -133,6 +139,7 @@ export default function Grades(props) {
 
   const handleCourseSelect = async (course) => {
     setCourse(course);
+    setSemester(null);
     const newAssignmentTypes = await GradesAPI.getAllAssignmentTypes(course);
     setAssignmentTypes(newAssignmentTypes);
   }
@@ -229,7 +236,18 @@ export default function Grades(props) {
       {/* Assignment Categories */}
       <main className={classes.content}>
         {/* Upcoming Assignments */}
-        {semester && !course && "Upcoming Assignments"}
+        {semester && !course && assignmentDates.map((date, index) => (
+          <div key={index}>
+            <Toolbar>
+              <Typography variant="h5" edge="start">{ new Date(date).toLocaleString('default', { month: 'long', day: 'numeric' }) }</Typography>
+            </Toolbar>
+            <GradesTable
+              upcoming={ true }
+              courses={ courses[semester.name] }
+              assignments={ upcomingAssignments[date] }
+            />
+          </div>
+        ))}
         {/* Assignment Tables */}
         {course && assignmentTypes.map((type, index) => (
           <div key={index}>
@@ -242,6 +260,7 @@ export default function Grades(props) {
             </Toolbar>
             <GradesTable
               type={ type }
+              course={ course }
               assignments={ assignments[type.name] }
               setAssignments={ setAssignments }
               setAnchorEl={ setAnchorEl }

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -152,10 +152,11 @@ export default function Grades(props) {
   useEffect(() => {
     const calculateCourseGrades = async () => {
       const updatedCourse = await GradesAPI.calculateCourseGrade(course._id);
+      const courseSemester = semesters.find(s => (s._id === updatedCourse.semester_id)).name;
       setCourse(updatedCourse);
       setCourses((state) => ({
         ...state,
-        [semester]: state[semester] ? state[semester].map((c) => (
+        [courseSemester]: state[courseSemester] ? state[courseSemester].map((c) => (
           c._id === updatedCourse._id ? updatedCourse : c
         )) : null,
       }));
@@ -163,7 +164,7 @@ export default function Grades(props) {
     if (course)
       calculateCourseGrades();
   }, [assignmentTypes]);
-
+  
   useEffect(() => {
     const calculateSemesterGrades = async () => {
       let newSemesters = [];

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -315,13 +315,13 @@ export default function Grades(props) {
           </div>
         ))}
         <Toolbar>
-          {course ? <Typography variant="h4">{ course.name } ({ course.grade ? course.grade.toFixed(2) + " - " + getLetterGrade(course) : 'N/A' })</Typography> : null }
+          {course ? <Typography variant="h4">{ course.name } ({ course.grade !== null ? course.grade.toFixed(2) + " - " + getLetterGrade(course) : 'N/A' })</Typography> : null }
         </Toolbar>
         {/* Assignment Tables */}
         {course && assignmentTypes.map((type, index) => (
           <div key={index}>
             <Toolbar>
-              <Typography variant="h5" edge="start">{ type.name } ({ type.grade ? type.grade.toFixed(2) : 'N/A' })</Typography>
+              <Typography variant="h5" edge="start">{ type.name } ({ type.grade !== null ? type.grade.toFixed(2) : 'N/A' })</Typography>
               <div className={classes.grow} />
               <IconButton edge="end" onClick={(e) => {setAnchorEl(e.target); setMenuType("assignment type"); setMenuTarget(type)}}>
                 <MoreHorizIcon />

--- a/client/src/pages/Grades.js
+++ b/client/src/pages/Grades.js
@@ -59,6 +59,7 @@ const useStyles = makeStyles((theme) => ({
 export default function Grades(props) {
   // Data states
   const [semesters, setSemesters] = useState([]);
+  const [dropdownSemester, setDropdownSemester] = useState("");
   const [semester, setSemester] = useState("");
   const [courses, setCourses] = useState({});
   const [course, setCourse] = useState(null);
@@ -111,11 +112,16 @@ export default function Grades(props) {
     fetchAndSetAssignments();
   }, [assignmentTypes]);
 
-  const handleSemesterClick = (name) => {
-    if (name === semester) {
-      setSemester("");
+  const handleSemesterClick = async (s) => {
+    setSemester(s);
+    setCourse(null);
+  }
+
+  const handleSemesterDropdown = (name) => {
+    if (name === dropdownSemester) {
+      setDropdownSemester("");
     } else {
-      setSemester(name);
+      setDropdownSemester(name);
     }
   }
 
@@ -156,19 +162,21 @@ export default function Grades(props) {
             <div key={index}>
               <ListItem
                 button
+                selected={ s === semester }
+                onClick={() => {handleSemesterClick(s)}}
               >
                 <ListItemText primary={s.name} />
                 <ListItemSecondaryAction className={classes.listItemSecondary}>
                   <IconButton onClick={(e) => {setAnchorEl(e.target); setMenuType("semester"); setMenuTarget(s)}}>
                     <MoreHorizIcon />
                   </IconButton>
-                  <IconButton onClick={() => {handleSemesterClick(s.name)}}>
-                    { semester === s.name ? <ExpandLess /> : <ExpandMore /> }
+                  <IconButton onClick={() => {handleSemesterDropdown(s.name)}}>
+                    { dropdownSemester === s.name ? <ExpandLess /> : <ExpandMore /> }
                   </IconButton>
                 </ListItemSecondaryAction>
               </ListItem>
               {/* List of courses for this semester */}
-              <Collapse in={semester === s.name} timeout="auto" unmountOnExit>
+              <Collapse in={dropdownSemester === s.name} timeout="auto" unmountOnExit>
                 <List disablePadding>
                   {courses[s.name] && courses[s.name].map((c, index) => (
                     <ListItem
@@ -220,8 +228,10 @@ export default function Grades(props) {
       </Drawer>
       {/* Assignment Categories */}
       <main className={classes.content}>
+        {/* Upcoming Assignments */}
+        {semester && !course && "Upcoming Assignments"}
         {/* Assignment Tables */}
-        {assignmentTypes.map((type, index) => (
+        {course && assignmentTypes.map((type, index) => (
           <div key={index}>
             <Toolbar>
               <Typography variant="h5" edge="start">{ type.name }</Typography>

--- a/client/src/pages/GradesAPI.js
+++ b/client/src/pages/GradesAPI.js
@@ -78,7 +78,12 @@ async function createAssignment(assignment) {
 }
 
 async function getAllAssignments(assignmentType) {
-  const { data: assignments } = await API.get(`${ASSIGNMENT_URL}${assignmentType._id}`);
+  const { data: assignments } = await API.get(`${ASSIGNMENT_URL}type/${assignmentType._id}`);
+  return assignments;
+}
+
+async function getAllUpcomingAssignments(semester) {
+  const { data: assignments } = await API.get(`${ASSIGNMENT_URL}upcoming/${semester._id}`);
   return assignments;
 }
 
@@ -96,5 +101,5 @@ export default {
   createSemester, getAllSemesters, updateSemester, deleteSemester,
   createCourse, getAllCourses, updateCourse, deleteCourse,
   createAssignmentType, getAllAssignmentTypes, updateAssignmentType, deleteAssignmentType,
-  createAssignment, getAllAssignments, updateAssignment, deleteAssignment,
+  createAssignment, getAllAssignments, getAllUpcomingAssignments, updateAssignment, deleteAssignment,
 }

--- a/server/models/grades/assignment.js
+++ b/server/models/grades/assignment.js
@@ -21,6 +21,14 @@ const assignmentSchema = new Schema({
   type_id: {
     type: Schema.Types.ObjectId,
     required: true,
+  },
+  course_id: {
+    type: Schema.Types.ObjectId,
+    required: true,
+  },
+  semester_id: {
+    type: Schema.Types.ObjectId,
+    required: true,
   }
 });
 

--- a/server/routes/grades/assignmentTypes.js
+++ b/server/routes/grades/assignmentTypes.js
@@ -75,7 +75,7 @@ router.post('/grade/:id', async (req, res, next) => {
     } else {
       assignments.splice(0, assignments.length-1);
     }
-    const grade = assignments.reduce((acc, val) => (acc + val.grade/assignments.length), 0);
+    const grade = assignments.length ? assignments.reduce((acc, val) => (acc + val.grade/assignments.length), 0) : null;
     const newAssignmentType = await AssignmentType.findByIdAndUpdate(req.params.id, {
       ...assignmentType._doc,
       grade,

--- a/server/routes/grades/assignments.js
+++ b/server/routes/grades/assignments.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { Assignment } = require('../../models');
+const { Course, AssignmentType, Assignment } = require('../../models');
 const router = express.Router();
 
 /**
@@ -18,10 +18,29 @@ router.post('/', async (req, res, next) => {
 
 /**
  * @route GET api/grades/assignments
+ * @description Gets all assignments that are incomplete for this semester
+ * @access private
+ */
+router.get('/upcoming/:semester', async (req, res, next) => {
+  try {
+    const assignments = await Assignment.find({ semester_id: req.params.semester, completed: false }, null, { sort: 'due_date' });
+    const grouped = assignments.reduce((acc, val) => ({
+      ...acc,
+      [val.due_date.toDateString()]: [...acc[val.due_date.toDateString()] || [], val],
+    }), {});
+    return res.status(200).json(grouped);
+  } catch (err) {
+    console.log(err);
+    next({ status: 400, message: 'Failed to get assignments' });
+  }
+});
+
+/**
+ * @route GET api/grades/assignments
  * @description Gets all assignments of certain type
  * @access private
  */
-router.get('/:type', async (req, res, next) => {
+router.get('/type/:type', async (req, res, next) => {
   try {
     const assignments = await Assignment.find({ type_id: req.params.type });
     return res.status(200).json(assignments);

--- a/server/routes/grades/courses.js
+++ b/server/routes/grades/courses.js
@@ -79,8 +79,8 @@ router.post('/grade/:id', async (req, res, next) => {
     const course = await Course.findById(req.params.id);
     const assignmentTypes = await AssignmentType.find({ course_id: req.params.id, grade: { $ne: null } });
     const totalWeight = assignmentTypes.reduce((acc, val) => (acc + val.weight), 0);
-    const grade = assignmentTypes.reduce((acc, val) => (acc + val.grade*val.weight/totalWeight), 0);
-    let grade_points = points['F'];
+    const grade = assignmentTypes.length ? assignmentTypes.reduce((acc, val) => (acc + val.grade*val.weight/totalWeight), 0) : null;
+    let grade_points = assignmentTypes.length ? points['F'] : null;
     for (const letter of Object.keys(course.cutoffs)) {
       if (grade >= course.cutoffs[letter]) {
         grade_points = points[letter] * course.hours;


### PR DESCRIPTION
### Problem
There is not currently a way to view all the assignments that are due soon. This stops the user from using this tool to keep track of what to do next.

### Solution
Add a page view that displays the assignments grouped by due date. For a given semester, clicking on that semester in the left pane will bring up a view of the assignments grouped by date with the closest date at the top. 

### Testing
I tested this by creating multiple semesters' worth of courses and assignments with different dates. I clicked back and forth and the items changed appropriately.

### Notes
There may be some merge conflicts between this and master once #53 is merged in. I'll fix those up before merging this in.

Closes #54